### PR TITLE
Fix for 404 pages on custom routes

### DIFF
--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -1,0 +1,5 @@
+{
+    "navigationFallback": {
+        "rewrite": "/index.html"
+    }
+}


### PR DESCRIPTION
Adding staticwebapp.config.json file with a navigationFallback rule per Azure's documentation: https://learn.microsoft.com/en-us/azure/static-web-apps/configuration#fallback-routes

Related to issue #18 azure version.