### PR TITLE
Replaced BSD 3-clause with ORNL license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,31 +3,15 @@ All rights reserved
  NEB-Tool
 OPEN SOURCE LICENSE (Permissive)
 
-Subject to the conditions of this License, Alliance for Sustainable Energy, LLC and UT-Battelle, LLC (the "Licensor") hereby grants, free of charge, to any person (the
-"Licensee") obtaining a copy of this software and associated documentation files (the "Software"), a perpetual, worldwide,
-non-exclusive, no-charge, royalty-free, irrevocable copyright license to use, copy, modify, merge, publish, distribute, and/or 
-sublicense copies of the Software.
+Subject to the conditions of this License, Alliance for Sustainable Energy, LLC and UT-Battelle, LLC (the "Licensors") hereby grant, free of charge, to any person (the "Licensee") obtaining a copy of this software and associated documentation files (the "Software"), a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to use, copy, modify, merge, publish, distribute, and/or sublicense copies of the Software.
 
-1. Redistributions of Software must retain the above open source license grant, copyright and license notices, this list of 
-conditions, and the disclaimer listed below.  Changes or modifications to, or derivative works of the Software must be noted 
-with comments and the contributor and organization's name.
+1. Redistributions of Software must retain the above open source license grant, copyright and license notices, this list of conditions, and the disclaimer listed below.  Changes or modifications to, or derivative works of the Software must be noted with comments and the contributor and organization's name.
 
-2. Neither the names of Licensor, the Department of Energy, or their employees may be used to endorse or promote products 
-derived from this Software without their specific prior written permission.
+2. Neither the names of Licensors, the Department of Energy, or their employees may be used to endorse or promote products derived from this Software without their specific prior written permission.
 
-3. If the Software is protected by a proprietary trademark owned by Licensor or the Department of Energy, then derivative 
-works of the Software may not be distributed using the trademark without the prior written approval of the trademark owner. 
-	
-
+3. If the Software is protected by a proprietary trademark owned by either Licensor or the Department of Energy, then derivative works of the Software may not be distributed using the trademark without the prior written approval of the trademark owner.
 
 ****************************************************************************************************************
 DISCLAIMER
-
-ALLIANCE FOR SUSTAINABLE ENERGY, LLC, UT-BATTELLE, LLC AND THE GOVERNMENT MAKE NO REPRESENTATIONS AND DISCLAIM ALL WARRANTIES, BOTH EXPRESSED AND IMPLIED.  THERE 
-ARE NO EXPRESS OR IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE, OR THAT THE USE OF THE SOFTWARE 
-WILL NOT INFRINGE ANY PATENT, COPYRIGHT, TRADEMARK, OR OTHER PROPRIETARY RIGHTS, OR THAT THE SOFTWARE WILL ACCOMPLISH THE 
-INTENDED RESULTS OR THAT THE SOFTWARE OR ITS USE WILL NOT RESULT IN INJURY OR DAMAGE.  THE USER ASSUMES RESPONSIBILITY FOR ALL 
-LIABILITIES, PENALTIES, FINES, CLAIMS, CAUSES OF ACTION, AND COSTS AND EXPENSES, CAUSED BY, RESULTING FROM OR ARISING OUT OF, 
-IN WHOLE OR IN PART THE USE, STORAGE OR DISPOSAL OF THE SOFTWARE.
-
+ALLIANCE FOR SUSTAINABLE ENERGY, LLC, UT-BATTELLE, LLC AND THE GOVERNMENT MAKE NO REPRESENTATIONS AND DISCLAIM ALL WARRANTIES, BOTH EXPRESSED AND IMPLIED.  THERE ARE NO EXPRESS OR IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE, OR THAT THE USE OF THE SOFTWARE WILL NOT INFRINGE ANY PATENT, COPYRIGHT, TRADEMARK, OR OTHER PROPRIETARY RIGHTS, OR THAT THE SOFTWARE WILL ACCOMPLISH THE INTENDED RESULTS OR THAT THE SOFTWARE OR ITS USE WILL NOT RESULT IN INJURY OR DAMAGE.  THE USER ASSUMES RESPONSIBILITY FOR ALL LIABILITIES, PENALTIES, FINES, CLAIMS, CAUSES OF ACTION, AND COSTS AND EXPENSES, CAUSED BY, RESULTING FROM OR ARISING OUT OF, IN WHOLE OR IN PART THE USE, STORAGE OR DISPOSAL OF THE SOFTWARE.
 ****************************************************************************************************************


### PR DESCRIPTION
As instructed by sponsors and agreed upon by the team, this pull request replaces the standard BSD-3 Clause license with an Oak Ridge permissive license. The copyright remains the same (joint copyright of Alliance for Sustainable Energy, LLC and UT-Battelle, LLC).

I suggest **squash and merge** for this PR to get rid of the multiple revisions of the license, which should not be attached to any version of the codebase.