### PR TITLE
Add "Assessment Management" to data collection section

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -35,6 +35,7 @@ import { OnSiteAssessmentComponent } from './setup-wizard/data-collection/on-sit
 import { ReviewOnSiteComponent } from './setup-wizard/data-collection/review-on-site/review-on-site.component';
 import { PreVisitComponent } from './setup-wizard/pre-visit/pre-visit.component';
 import { DataCollectionComponent } from './setup-wizard/data-collection/data-collection.component';
+import { DataCollectionManageAssessmentsComponent } from './setup-wizard/data-collection/data-collection-manage-assessments/data-collection-manage-assessments.component';
 
 const routes: Routes = [
   {
@@ -106,6 +107,10 @@ const routes: Routes = [
         path: 'data-collection/:id',
         component: DataCollectionComponent,
         children: [
+          {
+            path: 'manage-assessments',
+            component: DataCollectionManageAssessmentsComponent
+          },
           {
             path: 'assessment/:id',
             component: OnSiteAssessmentComponent

--- a/src/app/setup-wizard/data-collection/data-collection-manage-assessments/data-collection-manage-assessments.component.html
+++ b/src/app/setup-wizard/data-collection/data-collection-manage-assessments/data-collection-manage-assessments.component.html
@@ -58,10 +58,6 @@
 
 <nav class="setup-wizard-footer navbar shadow">
     <div class="container-fluid justify-content-end">
-        <!-- <button class="btn btn-dark" (click)="goBack()">
-            <fa-icon [icon]="faChevronLeft"></fa-icon>
-            Go Back
-        </button> -->
         <button class="btn btn-dark" (click)="goToNext()" [disabled]="onSiteVisit.assessmentIds.length == 0">
             Go to Assessment
             <fa-icon [icon]="faChevronRight"></fa-icon>

--- a/src/app/setup-wizard/data-collection/data-collection-manage-assessments/data-collection-manage-assessments.component.html
+++ b/src/app/setup-wizard/data-collection/data-collection-manage-assessments/data-collection-manage-assessments.component.html
@@ -1,0 +1,89 @@
+<div class="setup-wizard-content">
+    <div class="row g-0 justify-content-center h-100 w-100 overflow-scroll">
+        <div class="col-10 pt-4 pb-4">
+            <div class="form-paper shadow">
+                <h5>
+                    <fa-icon [icon]="faToolbox"></fa-icon> Manage Assessments
+                </h5>
+                <hr>
+                <div class="d-flex w-100 justify-content-between pb-2">
+                    <div class="p-0">
+                        <div class="row mb-1">
+                            <label class="col-sm-5 col-form-label bold" for="visitDate">Visit Date</label>
+                            <div class="col-sm-7">
+                                <input type="date" class="form-control" [(ngModel)]="onSiteVisit.visitDate"
+                                    name="visitDate" (change)="setVisitDate()">
+                            </div>
+                        </div>
+                    </div>
+                    <div class="p-0">
+                        <button class="btn btn-outline-success" (click)="addAssessment()">
+                            <fa-icon [icon]="faPlus"></fa-icon>
+                            Add Assessment
+                        </button>
+                    </div>
+                </div>
+
+                <ng-template [ngIf]="(onSiteVisit.assessmentIds | assessmentListOnSite: assessments).length != 0"
+                    [ngIfElse]="noAssessmentsBlock">
+                    <div class="list-group"
+                        *ngFor="let assessment of (onSiteVisit.assessmentIds | assessmentListOnSite: assessments); let assessmentIndex = index;">
+                        <div class="list-group-item">
+                            <div class="d-flex w-100 justify-content-between">
+                                <div class="p-0">
+                                    <fa-icon [icon]="faScrewdriverWrench" class="me-1"></fa-icon>
+                                    <a class="click-link" (click)="goToAssessment(assessment.guid)">{{assessment.name}}
+                                    </a>
+                                </div>
+                                <div class="p-0">
+                                    <button class="btn btn-sm btn-danger" (click)="openDeleteModal(assessment)">
+                                        <fa-icon [icon]="faTrash"></fa-icon>
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                </ng-template>
+                <ng-template #noAssessmentsBlock>
+                    <div class="alert alert-info text-center">
+                        No Assessments added. Click "Add Assessment" to add an assessment.
+                    </div>
+                </ng-template>
+            </div>
+        </div>
+    </div>
+</div>
+
+
+<nav class="setup-wizard-footer navbar shadow">
+    <div class="container-fluid justify-content-end">
+        <!-- <button class="btn btn-dark" (click)="goBack()">
+            <fa-icon [icon]="faChevronLeft"></fa-icon>
+            Go Back
+        </button> -->
+        <button class="btn btn-dark" (click)="goToNext()" [disabled]="onSiteVisit.assessmentIds.length == 0">
+            Go to Assessment
+            <fa-icon [icon]="faChevronRight"></fa-icon>
+        </button>
+    </div>
+</nav>
+
+
+<div [ngClass]="{'window-overlay': displayDeleteModal}"></div>
+<div class="popup" [ngClass]="{'open': displayDeleteModal }">
+    <div class="popup-header">Delete Assessment
+        <button type="button" class="btn-close float-end" aria-label="Close" (click)="closeDeleteModal()"></button>
+    </div>
+    <div class="popup-body">
+        <div class="alert alert-danger">
+            Are you sure you want to delete this assessment? This cannot be undone.
+        </div>
+        <hr>
+    </div>
+    <div class="popup-footer d-flex justify-content-end">
+        <button class="btn btn-secondary me-2" (click)="closeDeleteModal()">Cancel</button>
+        <button class="btn btn-danger" (click)="deleteAssessment()"><fa-icon [icon]="faTrash"></fa-icon> Delete
+            Assessment</button>
+    </div>
+</div>

--- a/src/app/setup-wizard/data-collection/data-collection-manage-assessments/data-collection-manage-assessments.component.spec.ts
+++ b/src/app/setup-wizard/data-collection/data-collection-manage-assessments/data-collection-manage-assessments.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DataCollectionManageAssessmentsComponent } from './data-collection-manage-assessments.component';
+
+describe('DataCollectionManageAssessmentsComponent', () => {
+  let component: DataCollectionManageAssessmentsComponent;
+  let fixture: ComponentFixture<DataCollectionManageAssessmentsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [DataCollectionManageAssessmentsComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(DataCollectionManageAssessmentsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/setup-wizard/data-collection/data-collection-manage-assessments/data-collection-manage-assessments.component.spec.ts
+++ b/src/app/setup-wizard/data-collection/data-collection-manage-assessments/data-collection-manage-assessments.component.spec.ts
@@ -1,14 +1,36 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { DataCollectionManageAssessmentsComponent } from './data-collection-manage-assessments.component';
+import { FormsModule } from '@angular/forms';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { AssessmentIdbService } from 'src/app/indexed-db/assessment-idb.service';
+import { IdbAssessment } from 'src/app/models/assessment';
+import { OnSiteVisitIdbService } from 'src/app/indexed-db/on-site-visit-idb.service';
+import { IdbOnSiteVisit, getNewIdbOnSiteVisit } from 'src/app/models/onSiteVisit';
+import { BehaviorSubject } from 'rxjs';
+import { DbChangesService } from 'src/app/indexed-db/db-changes.service';
+import { HelperPipesModule } from 'src/app/shared/helper-pipes/helper-pipes.module';
 
 describe('DataCollectionManageAssessmentsComponent', () => {
   let component: DataCollectionManageAssessmentsComponent;
   let fixture: ComponentFixture<DataCollectionManageAssessmentsComponent>;
 
+  let assessmentIdbService: Partial<AssessmentIdbService> = {
+    assessments: new BehaviorSubject<Array<IdbAssessment>>([])
+  };
+  let onSiteVisitIdbService: Partial<OnSiteVisitIdbService> = {
+    selectedVisit: new BehaviorSubject<IdbOnSiteVisit>(getNewIdbOnSiteVisit('', '', ''))
+  };
+  let dbChangesService: Partial<DbChangesService> = {}
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [DataCollectionManageAssessmentsComponent]
+      imports: [FormsModule, FontAwesomeModule, HelperPipesModule],
+      declarations: [DataCollectionManageAssessmentsComponent],
+      providers: [
+        { provide: AssessmentIdbService, useValue: assessmentIdbService },
+        { provide: OnSiteVisitIdbService, useValue: onSiteVisitIdbService },
+        { provide: DbChangesService, useValue: dbChangesService }
+      ]
     })
     .compileComponents();
     

--- a/src/app/setup-wizard/data-collection/data-collection-manage-assessments/data-collection-manage-assessments.component.ts
+++ b/src/app/setup-wizard/data-collection/data-collection-manage-assessments/data-collection-manage-assessments.component.ts
@@ -1,0 +1,107 @@
+import { Component } from '@angular/core';
+import { Router } from '@angular/router';
+import { IconDefinition, faChevronLeft, faChevronRight, faPlus, faScrewdriverWrench, faToolbox, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { Subscription, firstValueFrom } from 'rxjs';
+import { AssessmentIdbService } from 'src/app/indexed-db/assessment-idb.service';
+import { DbChangesService } from 'src/app/indexed-db/db-changes.service';
+import { OnSiteVisitIdbService } from 'src/app/indexed-db/on-site-visit-idb.service';
+import { IdbAssessment, getNewIdbAssessment } from 'src/app/models/assessment';
+import { IdbOnSiteVisit } from 'src/app/models/onSiteVisit';
+
+@Component({
+  selector: 'app-data-collection-manage-assessments',
+  templateUrl: './data-collection-manage-assessments.component.html',
+  styleUrl: './data-collection-manage-assessments.component.css'
+})
+export class DataCollectionManageAssessmentsComponent {
+
+  faToolbox: IconDefinition = faToolbox;
+  faChevronRight: IconDefinition = faChevronRight;
+  faChevronLeft: IconDefinition = faChevronLeft;
+  faPlus: IconDefinition = faPlus;
+  faScrewdriverWrench: IconDefinition = faScrewdriverWrench;
+  faTrash: IconDefinition = faTrash;
+
+  onSiteVisit: IdbOnSiteVisit;
+  onSiteVisitSub: Subscription;
+
+  assessmentsSub: Subscription;
+  assessments: Array<IdbAssessment>;
+  displayDeleteModal: boolean = false;
+  assessmentToDelete: IdbAssessment;
+  constructor(private router: Router, private assessmentIdbService: AssessmentIdbService,
+    private onSiteVisitIdbService: OnSiteVisitIdbService,
+    private dbChangesService: DbChangesService
+  ) {
+  }
+
+  ngOnInit() {
+    this.onSiteVisitSub = this.onSiteVisitIdbService.selectedVisit.subscribe(_onSiteVisit => {
+      this.onSiteVisit = _onSiteVisit;
+    });
+
+    this.assessmentsSub = this.assessmentIdbService.assessments.subscribe(_assessments => {
+      this.assessments = _assessments;
+    });
+  }
+
+  ngOnDestroy() {
+    this.onSiteVisitSub.unsubscribe();
+    this.assessmentsSub.unsubscribe();
+
+  }
+
+
+  goBack() {
+    let onSiteVisit: IdbOnSiteVisit = this.onSiteVisitIdbService.selectedVisit.getValue();
+    this.router.navigateByUrl('setup-wizard/pre-visit/' + onSiteVisit.guid + '/process-equipment');
+  }
+
+  goToNext() {
+    this.goToAssessment(this.onSiteVisit.assessmentIds[0])
+  }
+
+  async addAssessment() {
+    let assessment: IdbAssessment = getNewIdbAssessment(this.onSiteVisit.userId, this.onSiteVisit.companyId, this.onSiteVisit.facilityId);
+    assessment.visitDate = this.onSiteVisit.visitDate;
+    await firstValueFrom(this.assessmentIdbService.addWithObservable(assessment));
+    await this.assessmentIdbService.setAssessments();
+    this.onSiteVisit.assessmentIds.push(assessment.guid);
+    await this.onSiteVisitIdbService.asyncUpdate(this.onSiteVisit);
+  }
+
+
+  async saveChanges(assessment: IdbAssessment) {
+    this.assessmentIdbService.asyncUpdate(assessment);
+  }
+
+  async setVisitDate() {
+    for (let i = 0; i < this.assessments.length; i++) {
+      if (this.onSiteVisit.assessmentIds.includes(this.assessments[i].guid)) {
+        this.assessments[i].visitDate = this.onSiteVisit.visitDate;
+        await this.saveChanges(this.assessments[i]);
+      }
+    }
+    await this.onSiteVisitIdbService.asyncUpdate(this.onSiteVisit);
+  }
+
+  async deleteAssessment() {
+    await this.dbChangesService.deleteAssessment(this.assessmentToDelete);
+    this.closeDeleteModal();
+  }
+
+  openDeleteModal(assessment: IdbAssessment) {
+    this.assessmentToDelete = assessment;
+    this.displayDeleteModal = true;
+  }
+
+  closeDeleteModal() {
+    this.displayDeleteModal = false;
+    this.assessmentToDelete = undefined;
+  }
+
+  goToAssessment(guid: string) {
+    this.router.navigateByUrl('/setup-wizard/data-collection/' + this.onSiteVisit.guid + '/assessment/' + guid);
+  }
+
+}

--- a/src/app/setup-wizard/data-collection/on-site-assessment/on-site-assessment.component.html
+++ b/src/app/setup-wizard/data-collection/on-site-assessment/on-site-assessment.component.html
@@ -44,6 +44,10 @@
 <nav class="setup-wizard-footer navbar shadow">
     <div class="container-fluid justify-content-between">
         <div class="col-3">
+            <button class="btn btn-dark" (click)="goBack()"
+                *ngIf="assessmentIndex == 0">
+                <fa-icon [icon]="faChevronLeft"></fa-icon>
+            </button>
             <button class="btn btn-dark" (click)="goToPrevious()" *ngIf="assessmentIndex != 0">
                 <fa-icon [icon]="faChevronLeft"></fa-icon>
             </button>
@@ -72,6 +76,7 @@
         </div>
         <div class="col-3">
             <div class="d-flex  justify-content-end">
+
                 <button class="btn btn-dark" (click)="goToNextAssessment()"
                     *ngIf="assessmentIndex != onSiteVisit.assessmentIds.length-1">
                     <fa-icon [icon]="faChevronRight"></fa-icon>

--- a/src/app/setup-wizard/data-collection/on-site-assessment/on-site-assessment.component.ts
+++ b/src/app/setup-wizard/data-collection/on-site-assessment/on-site-assessment.component.ts
@@ -41,7 +41,7 @@ export class OnSiteAssessmentComponent {
   assessmentIndex: number;
   onSiteVisit: IdbOnSiteVisit;
   onSiteVisitSub: Subscription;
-  constructor(private router: Router, private assessmentIdbService: AssessmentIdbService, 
+  constructor(private router: Router, private assessmentIdbService: AssessmentIdbService,
     private activatedRoute: ActivatedRoute,
     private contactIdbService: ContactIdbService,
     private onSiteVisitIdbService: OnSiteVisitIdbService
@@ -68,7 +68,7 @@ export class OnSiteAssessmentComponent {
       } else if (this.assessmentIndex == -1 && this.onSiteVisit.assessmentIds.length > 0) {
         this.navigateToOnSiteAssessment(this.onSiteVisit.assessmentIds[0]);
       } else if (!this.assessment) {
-        this.router.navigateByUrl('/setup-wizard');
+        this.router.navigateByUrl('/setup-wizard/data-collection/' + this.onSiteVisit.guid + '/manage-assessments');
       }
     });
   }
@@ -105,7 +105,7 @@ export class OnSiteAssessmentComponent {
     this.router.navigateByUrl('/setup-wizard/data-collection/' + this.onSiteVisit.guid + '/review-data-collection');
   }
 
-  goBack(){
+  goBack() {
     this.router.navigateByUrl('/setup-wizard/data-collection/' + this.onSiteVisit.guid + '/manage-assessments');
   }
 }

--- a/src/app/setup-wizard/data-collection/on-site-assessment/on-site-assessment.component.ts
+++ b/src/app/setup-wizard/data-collection/on-site-assessment/on-site-assessment.component.ts
@@ -104,4 +104,8 @@ export class OnSiteAssessmentComponent {
   goToResults() {
     this.router.navigateByUrl('/setup-wizard/data-collection/' + this.onSiteVisit.guid + '/review-data-collection');
   }
+
+  goBack(){
+    this.router.navigateByUrl('/setup-wizard/data-collection/' + this.onSiteVisit.guid + '/manage-assessments');
+  }
 }

--- a/src/app/setup-wizard/getting-started/getting-started.component.ts
+++ b/src/app/setup-wizard/getting-started/getting-started.component.ts
@@ -104,7 +104,11 @@ export class GettingStartedComponent {
       this.router.navigateByUrl('/setup-wizard/pre-visit/' + this.selectedOnSiteVisitGuid);
     } else if (context == 'onSite') {
       let onSiteVisit: IdbOnSiteVisit = this.onSiteVisitIdbService.getByGuid(this.selectedOnSiteVisitGuid);
-      this.router.navigateByUrl('/setup-wizard/data-collection/' + this.selectedOnSiteVisitGuid + '/assessment/' + onSiteVisit.assessmentIds[0]);
+      if (onSiteVisit.assessmentIds.length > 0) {
+        this.router.navigateByUrl('/setup-wizard/data-collection/' + this.selectedOnSiteVisitGuid + '/assessment/' + onSiteVisit.assessmentIds[0]);
+      } else {
+        this.router.navigateByUrl('/setup-wizard/data-collection/' + this.selectedOnSiteVisitGuid + '/manage-assessments');
+      }
     } else if (context == 'postVisit') {
       // this.router.navigateByUrl('/setup-wizard/project-setup');
     }

--- a/src/app/setup-wizard/pre-visit/pre-assessment-setup/pre-assessment-setup.component.spec.ts
+++ b/src/app/setup-wizard/pre-visit/pre-assessment-setup/pre-assessment-setup.component.spec.ts
@@ -17,6 +17,7 @@ import { IdbOnSiteVisit, getNewIdbOnSiteVisit } from 'src/app/models/onSiteVisit
 import { ContactIdbService } from 'src/app/indexed-db/contact-idb.service';
 import { IdbContact } from 'src/app/models/contact';
 import { HelperPipesModule } from 'src/app/shared/helper-pipes/helper-pipes.module';
+import { DbChangesService } from 'src/app/indexed-db/db-changes.service';
 
 describe('PreAssessmentSetupComponent', () => {
   let component: PreAssessmentSetupComponent;
@@ -42,6 +43,8 @@ describe('PreAssessmentSetupComponent', () => {
   let contactIdbService: Partial<ContactIdbService> = {
     contacts: new BehaviorSubject<Array<IdbContact>>([])
   };
+
+  let dbChangesService: Partial<DbChangesService> = {}
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [FontAwesomeModule, FormsModule, HelperPipesModule],
@@ -52,7 +55,8 @@ describe('PreAssessmentSetupComponent', () => {
         { provide: FacilityIdbService, useValue: facilityIdbService },
         { provide: AssessmentIdbService, useValue: assessmentIdbService },
         { provide: OnSiteVisitIdbService, useValue: onSiteVisitIdbService },
-        { provide: ContactIdbService, useValue: contactIdbService }
+        { provide: ContactIdbService, useValue: contactIdbService },
+        { provide: DbChangesService, useValue: dbChangesService }
       ]
     })
       .compileComponents();

--- a/src/app/setup-wizard/pre-visit/pre-assessment-setup/pre-assessment-setup.component.ts
+++ b/src/app/setup-wizard/pre-visit/pre-assessment-setup/pre-assessment-setup.component.ts
@@ -11,6 +11,7 @@ import { OnSiteVisitIdbService } from 'src/app/indexed-db/on-site-visit-idb.serv
 import { IdbOnSiteVisit } from 'src/app/models/onSiteVisit';
 import { Subscription, firstValueFrom } from 'rxjs';
 import { ContactIdbService } from 'src/app/indexed-db/contact-idb.service';
+import { DbChangesService } from 'src/app/indexed-db/db-changes.service';
 
 @Component({
   selector: 'app-pre-assessment-setup',
@@ -47,7 +48,8 @@ export class PreAssessmentSetupComponent {
   constructor(private router: Router, private assessmentIdbService: AssessmentIdbService,
     private facilityIdbService: FacilityIdbService,
     private onSiteVisitIdbService: OnSiteVisitIdbService,
-    private contactIdbService: ContactIdbService
+    private contactIdbService: ContactIdbService,
+    private dbChangesService: DbChangesService
   ) {
   }
 
@@ -122,31 +124,7 @@ export class PreAssessmentSetupComponent {
   }
 
   async removeAssessment() {
-    this.assessments = this.assessments.filter(_assessment => {
-      return _assessment.guid != this.assessmentToDelete.guid;
-    });
-    //update contacts
-    let facilityContacts: Array<IdbContact> = this.contacts.filter(contact => {
-      return contact.facilityIds.includes(this.onSiteVisit.facilityId);
-    });
-    let contactsNeedUpdate: boolean = false;
-    for (let i = 0; i < facilityContacts.length; i++) {
-      if (facilityContacts[i].assessmentIds.includes(this.assessmentToDelete.guid)) {
-        facilityContacts[i].assessmentIds = facilityContacts[i].assessmentIds.filter(guid => {
-          return guid != this.assessmentToDelete.guid;
-        });
-        await firstValueFrom(this.contactIdbService.updateWithObservable(facilityContacts[i]));
-        contactsNeedUpdate = true;
-      };
-    }
-    if (contactsNeedUpdate) {
-      await this.contactIdbService.setContacts()
-    }
-
-    this.onSiteVisit.assessmentIds = this.onSiteVisit.assessmentIds.filter(guid => {
-      return guid != this.assessmentToDelete.guid
-    });
-    await this.onSiteVisitIdbService.asyncUpdate(this.onSiteVisit);
+    await this.dbChangesService.deleteAssessment(this.assessmentToDelete);
     this.closeDeleteModal();
     this.setAccordionIndex(0);
   }

--- a/src/app/setup-wizard/setup-wizard-sidebar/setup-wizard-sidebar.component.html
+++ b/src/app/setup-wizard/setup-wizard-sidebar/setup-wizard-sidebar.component.html
@@ -72,6 +72,12 @@
                 <div class="p-2 w-100 text-bg-dark">
                     Data Collection
                 </div>
+                <div class="nav-item">
+                    <a class="nav-link" [routerLink]="'data-collection/'+onSiteVisit.guid+'/manage-assessments/'"
+                        [routerLinkActive]="['active']">
+                        Manage Assessments
+                    </a>
+                </div>
                 <ng-container *ngFor="let assessmentGuid of onSiteVisit.assessmentIds">
                     <div class="nav-item">
                         <a class="nav-link"

--- a/src/app/setup-wizard/setup-wizard.module.ts
+++ b/src/app/setup-wizard/setup-wizard.module.ts
@@ -39,6 +39,7 @@ import { AssessmentNebsFormComponent } from './data-collection/on-site-assessmen
 import { NebSetupFormComponent } from './data-collection/on-site-assessment/assessment-nebs-form/neb-setup-form/neb-setup-form.component';
 import { PreVisitComponent } from './pre-visit/pre-visit.component';
 import { DataCollectionComponent } from './data-collection/data-collection.component';
+import { DataCollectionManageAssessmentsComponent } from './data-collection/data-collection-manage-assessments/data-collection-manage-assessments.component';
 
 
 
@@ -75,7 +76,8 @@ import { DataCollectionComponent } from './data-collection/data-collection.compo
     AssessmentNebsFormComponent,
     NebSetupFormComponent,
     PreVisitComponent,
-    DataCollectionComponent
+    DataCollectionComponent,
+    DataCollectionManageAssessmentsComponent
   ],
   imports: [
     CommonModule,


### PR DESCRIPTION
connects #74 

After review it was noticed that you can not navigate to the the data collection page without adding in pre-assessments. 

Added in an "Assessment Management" page to the data collection portion that allows for the creation of new assessments and can delete assessments from here too. This will be navigated too if a user goes to data collection without setting up assessments in the pre-visit.