### PR TITLE
Issue 65 wrap up for facility page

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -88,7 +88,8 @@ const routes: Routes = [
           },
           {
             path: 'facility-setup',
-            component: FacilitySetupComponent
+            component: FacilitySetupComponent,
+            canDeactivate: [CanDeactivateGuard]
           },
           {
             path: 'energy-equipment',

--- a/src/app/setup-wizard/pre-visit/facility-setup/facility-setup.component.html
+++ b/src/app/setup-wizard/pre-visit/facility-setup/facility-setup.component.html
@@ -39,3 +39,14 @@
         </button>
     </div>
 </nav>
+<div [ngClass]="{'window-overlay': routeGuardWarningModal}"></div>
+<div class="popup" [ngClass]="{'open': routeGuardWarningModal }">
+    <div class="popup-body">
+        <div class="alert alert-danger">
+            Please fill the required fields.
+        </div>
+    </div>
+    <div class="popup-footer d-flex justify-content-end">
+        <button class="btn btn-secondary me-2" (click)="closeWarningModal()">OK</button>
+    </div>
+</div>

--- a/src/app/setup-wizard/pre-visit/facility-setup/facility-setup.component.html
+++ b/src/app/setup-wizard/pre-visit/facility-setup/facility-setup.component.html
@@ -3,6 +3,7 @@
         <div class="col-10 pt-4 pb-4">
             <div class="form-paper shadow">
                 <h5>
+                    <fa-icon [icon]="faCircleExclamation" class="pe-1 fa-error" *ngIf="name?.touched && name.invalid"></fa-icon>
                     <fa-icon [icon]="faIndustry" class="me-2"></fa-icon>Facility Details
                 </h5>
                 <hr>

--- a/src/app/setup-wizard/pre-visit/facility-setup/facility-setup.component.ts
+++ b/src/app/setup-wizard/pre-visit/facility-setup/facility-setup.component.ts
@@ -6,6 +6,7 @@ import { FacilityIdbService } from 'src/app/indexed-db/facility-idb.service';
 import { IdbOnSiteVisit } from 'src/app/models/onSiteVisit';
 import { OnSiteVisitIdbService } from 'src/app/indexed-db/on-site-visit-idb.service';
 import { FormControl, Validators } from '@angular/forms';
+import { Observable, of } from 'rxjs';
 
 @Component({
   selector: 'app-facility-setup',
@@ -26,6 +27,8 @@ export class FacilitySetupComponent implements OnInit {
   faIndustry: IconDefinition = faIndustry;
 
   facility: IdbFacility;
+  routeGuardWarningModal: boolean = false;
+
   constructor(private facilityIdbService: FacilityIdbService, private router: Router,
     private onSiteVisitIdbService: OnSiteVisitIdbService
   ) {
@@ -56,5 +59,21 @@ export class FacilitySetupComponent implements OnInit {
   goToProcessEquipment() {
     let onSiteVisit: IdbOnSiteVisit = this.onSiteVisitIdbService.selectedVisit.getValue();
     this.router.navigateByUrl('setup-wizard/pre-visit/' + onSiteVisit.guid + '/process-equipment');
+  }
+
+  canDeactivate(): Observable<boolean> {
+    if (this.name && this.name.getError('required')) {
+      this.name.markAsTouched();
+      this.dislayWarningModal();
+      return of(false);
+    }
+    return of(true);
+  }
+
+  dislayWarningModal() {
+    this.routeGuardWarningModal = true;
+  }
+  closeWarningModal() {
+    this.routeGuardWarningModal = false;
   }
 }

--- a/src/app/setup-wizard/pre-visit/facility-setup/facility-setup.component.ts
+++ b/src/app/setup-wizard/pre-visit/facility-setup/facility-setup.component.ts
@@ -1,12 +1,13 @@
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { IdbFacility } from 'src/app/models/facility';
-import { IconDefinition, faChevronLeft, faChevronRight, faContactCard, faFilePen, faGear, faIndustry, faLocationDot } from '@fortawesome/free-solid-svg-icons';
+import { IconDefinition, faChevronLeft, faChevronRight, faContactCard, faFilePen, faGear, faIndustry, faLocationDot, faCircleExclamation } from '@fortawesome/free-solid-svg-icons';
 import { FacilityIdbService } from 'src/app/indexed-db/facility-idb.service';
 import { IdbOnSiteVisit } from 'src/app/models/onSiteVisit';
 import { OnSiteVisitIdbService } from 'src/app/indexed-db/on-site-visit-idb.service';
 import { FormControl, Validators } from '@angular/forms';
 import { Observable, of } from 'rxjs';
+import { Icon } from '@fortawesome/fontawesome-svg-core';
 
 @Component({
   selector: 'app-facility-setup',
@@ -25,6 +26,7 @@ export class FacilitySetupComponent implements OnInit {
   faContactCard: IconDefinition = faContactCard;
   faLocationDot: IconDefinition = faLocationDot;
   faIndustry: IconDefinition = faIndustry;
+  faCircleExclamation: IconDefinition = faCircleExclamation;
 
   facility: IdbFacility;
   routeGuardWarningModal: boolean = false;

--- a/src/app/shared/shared-settings-forms/location-form/location-form.component.html
+++ b/src/app/shared/shared-settings-forms/location-form/location-form.component.html
@@ -17,7 +17,7 @@
         <div class="col-6">
             <label for="state">State/Province</label>
             <ng-container *ngIf="(inCompany && company?.generalInformation.country === 'US') || 
-                (!inCompany && company?.generalInformation.country === 'US'); else province">
+                (!inCompany && facility?.generalInformation.country === 'US'); else province">
                 <select class="form-select" formControlName="state" (change)="saveChanges()" id="state" name="state">
                     <option *ngFor="let state of states" [ngValue]="state.name">{{state.name}}</option>
                 </select>

--- a/src/app/shared/shared-settings-forms/location-form/location-form.component.html
+++ b/src/app/shared/shared-settings-forms/location-form/location-form.component.html
@@ -35,7 +35,7 @@
             <label for="zip">Zip</label>
             <input type="text" class="form-control" formControlName="zip" (input)="saveChanges()" minlength="1"
                 maxlength="12" id="zip" name="zip">
-            <div class="alert alert-warning form-error" *ngIf="form.controls['zip'].touched && form.controls['zip'].getError('invalidZipCode')">
+            <div class="alert alert-warning form-error" *ngIf="form.controls['zip'].getError('invalidZipCode')">
                 Invalid zip code.
             </div>
         </div>


### PR DESCRIPTION
connect to #142 #143 and #117 

Wrap up data validations for facility page, so it has the same validations as the company details page
- add router guards to facility page (#142) thus #143 is not necessary and should be closed
- add a warning icon for missing facility name (#117)
- correct the UI logic for state list when USA is chosen