### PR TITLE
branch issue-39: add an option to add backup data to current user besides overwriting

### DIFF
--- a/src/app/core-components/import-backup-modal/import-backup-modal.component.html
+++ b/src/app/core-components/import-backup-modal/import-backup-modal.component.html
@@ -23,6 +23,24 @@
             </div>
         </div>
 
+        <div class="d-flex flex-column pt-3"
+            *ngIf="importFile !== undefined && importFileError === undefined && importForUser">
+            <div class="input-group">
+                <label class="w-50 ps-0 bold">
+                    Overwrite Current User Data?
+                </label>
+                <select class="form-select w-50" [(ngModel)]="overwriteData" name="overwriteData">
+                    <option [ngValue]="true">Overwrite current user</option>
+                    <option [ngValue]="false">Add to current user</option>
+                </select>
+            </div>
+            <p class="alert alert-warning mt-3" *ngIf="overwriteData">
+                Current user data will be overwritten. This cannot be undone.
+            </p>
+        </div>
+
+        
+
     </div>
     <hr>
     <div class="popup-footer d-flex justify-content-end">

--- a/src/app/core-components/import-backup-modal/import-backup-modal.component.ts
+++ b/src/app/core-components/import-backup-modal/import-backup-modal.component.ts
@@ -106,9 +106,9 @@ export class ImportBackupModalComponent implements OnInit, OnDestroy {
       let tmpBackupFile: BackupFile = JSON.parse(this.importFile);
       if (this.importForUser) {
         if (this.overwriteData) {
-          await this.importExistingAccount(tmpBackupFile);
+          await this.overwriteCurrentUser(tmpBackupFile);
         } else {
-          await this.importNewAccount(tmpBackupFile);
+          await this.addToCurrentUser(tmpBackupFile);
         }
       }
       this.loadingService.setLoadingStatus(false);
@@ -121,16 +121,18 @@ export class ImportBackupModalComponent implements OnInit, OnDestroy {
     }
   }
 
-  async importNewAccount(importFile: BackupFile) {
-    let newUser: IdbUser = await this.backupDataService.importUserBackupFile(importFile);
-    await this.dbChangesService.selectUser(newUser, false);
+  async addToCurrentUser(importFile: BackupFile) {
+    // Add backup data to current user
+    await this.backupDataService.importUserBackupFile(importFile, this.currentUser.guid);
+    await this.dbChangesService.selectUser(this.currentUser, false);
   }
 
-  async importExistingAccount(importFile: BackupFile) {
-    // Overwrite current user with backup file content
-    // Delete current user and related data
-    await this.dbChangesService.deleteCurrentUser(this.currentUser);
-    await this.importNewAccount(importFile);
+  async overwriteCurrentUser(importFile: BackupFile) {
+    // Delete data for current user
+    this.loadingService.setLoadingMessage('Deleting Current User Data...');
+    await this.dbChangesService.deleteCurrentUserData(this.currentUser);
+    // Add backup data to current user
+    await this.addToCurrentUser(importFile);
   }
 
 }

--- a/src/app/indexed-db/db-changes.service.ts
+++ b/src/app/indexed-db/db-changes.service.ts
@@ -327,14 +327,13 @@ export class DbChangesService {
   }
 
   // TODO: Multiple users, to set a new when the current is deleted
-  async deleteCurrentUser(user: IdbUser) {
+  // Wipe off the data under current user
+  async deleteCurrentUserData(user: IdbUser) {
     let companies: Array<IdbCompany> = await firstValueFrom(this.companyIdbService.getAll());
     let userCompanies: Array<IdbCompany> = companies.filter(company => {return company.userId === user.guid});
     for (let i = 0; i < userCompanies.length; i++) {
       await this.deleteCompany(userCompanies[i]);
     }
-    await this.userIdbService.deleteUserWithObservable(user.id);
-    // await this.userIdbService.setUser();
   }
 
   async selectUser(user: IdbUser, skipUpdates: boolean) {

--- a/src/app/shared/shared-services/backup-data.service.ts
+++ b/src/app/shared/shared-services/backup-data.service.ts
@@ -87,17 +87,16 @@ export class BackupDataService {
     return backupFile;
   }
 
-  async importUserBackupFile(backupFile: BackupFile): Promise<IdbUser> {
-    // Overwirte existing user with new GUIDs for all dbEntries
-    // this.analyticsService.sendEvent('import_backup_file');
-    this.loadingService.setLoadingMessage('Adding Account...');
+  // Add backup file data to the userGuid
+  async importUserBackupFile(backupFile: BackupFile, userGuid: string): Promise<void> {
+    // Overwrite backup user guid with input guid
+    this.loadingService.setLoadingMessage('Adding Backup Data to User: ' + userGuid + '...');
     let userGUIDs: { oldId: string, newId: string } = {
       oldId: backupFile.user.guid,
-      newId: getGUID()
+      newId: userGuid
     }
     delete backupFile.user.id;
     backupFile.user.guid = userGUIDs.newId;
-    let newUser: IdbUser = await firstValueFrom(this.userIdbService.addWithObservable(backupFile.user));
 
     // Adding companies
     this.loadingService.setLoadingMessage('Adding Companies...');
@@ -291,7 +290,6 @@ export class BackupDataService {
       await firstValueFrom(this.onSiteVisitIdbService.addWithObservable(onsitevisit));
     }
 
-    return newUser;
   }
 
   backupFileVersionCheck(fileVersion: string, appVersion: string): boolean {


### PR DESCRIPTION
this connects to #157 
- When selected back up file, a selection list is offered to either 1. overwrite the data of current user, or 2. add backup data to current user.
- Note that the current user is reused in both options. The current user guid will be used to replace the user guid in backup file and the other guids in the backup file will be replaced with new guids generated randomly. This works even the user guid of current user matches with user guid in backup file.