### PR TITLE
add ability to lock baseline values after editing

### DIFF
--- a/src/app/setup-wizard/data-collection/on-site-assessment/neb-forms-accordion/neb-setup-form/performance-metric-impact-form/performance-metric-impact-form.component.html
+++ b/src/app/setup-wizard/data-collection/on-site-assessment/neb-forms-accordion/neb-setup-form/performance-metric-impact-form/performance-metric-impact-form.component.html
@@ -10,8 +10,13 @@
                     </button>
                     <ul class="dropdown-menu">
                         <li *ngIf="!overrideBaseline && metricHasOtherImpacts">
-                            <a class="dropdown-item" (click)="setOverrideBaseline()">
+                            <a class="dropdown-item" (click)="setOverrideBaseline(true)">
                                 <fa-icon [icon]="faEdit"></fa-icon> Edit Baseline Values
+                            </a>
+                        </li>
+                        <li *ngIf="overrideBaseline">
+                            <a class="dropdown-item" (click)="setOverrideBaseline(false)">
+                                <fa-icon [icon]="faLock"></fa-icon> Lock Baseline Values
                             </a>
                         </li>
                         <li>

--- a/src/app/setup-wizard/data-collection/on-site-assessment/neb-forms-accordion/neb-setup-form/performance-metric-impact-form/performance-metric-impact-form.component.ts
+++ b/src/app/setup-wizard/data-collection/on-site-assessment/neb-forms-accordion/neb-setup-form/performance-metric-impact-form/performance-metric-impact-form.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input } from '@angular/core';
 import { Router } from '@angular/router';
-import { IconDefinition, faBullseye, faClose, faEdit, faPlus, faScaleUnbalancedFlip, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { IconDefinition, faBullseye, faClose, faEdit, faLock, faPlus, faScaleUnbalancedFlip, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { firstValueFrom, Subscription } from 'rxjs';
 import { KeyPerformanceIndicatorsIdbService } from 'src/app/indexed-db/key-performance-indicators-idb.service';
 import { KeyPerformanceMetricImpactsIdbService } from 'src/app/indexed-db/key-performance-metric-impacts-idb.service';
@@ -28,6 +28,7 @@ export class PerformanceMetricImpactFormComponent {
   faTrash: IconDefinition = faTrash;
   faEdit: IconDefinition = faEdit;
   faBullseye: IconDefinition = faBullseye;
+  faLock: IconDefinition = faLock;
 
   keyPerformanceMetric: KeyPerformanceMetric;
   overrideBaseline: boolean = false;
@@ -124,7 +125,7 @@ export class PerformanceMetricImpactFormComponent {
     await this.keyPerformanceMetricImpactIdbService.setKeyPerformanceMetricImpacts();
   }
 
-  setOverrideBaseline() {
-    this.overrideBaseline = true;
+  setOverrideBaseline(overrideBaseline: boolean) {
+    this.overrideBaseline = overrideBaseline;
   }
 }


### PR DESCRIPTION
connects #141 

Kristina requested that we have the ability to re-lock the baseline values after they have been edited.