### PR TITLE
renamed EnergySteamUnitOptions to EnergySteamMixedUnitOptions

### DIFF
--- a/src/app/shared/constants/unitOptions.ts
+++ b/src/app/shared/constants/unitOptions.ts
@@ -178,7 +178,7 @@ export const VolumeGasOptions: Array<UnitOption> = [
     },
 ]
 
-export const EnergySteamUnitOptions: Array<UnitOption> = [
+export const EnergySteamMixedUnitOptions: Array<UnitOption> = [
     {
         display: 'Pounds (lb)',
         value: 'lb',

--- a/src/app/shared/constants/utilityTypes.ts
+++ b/src/app/shared/constants/utilityTypes.ts
@@ -1,4 +1,4 @@
-import { EnergyUnitOptions, MassUnitOptions, PowerUnitOptions, EnergySteamUnitOptions, UnitOption, VolumeGasOptions, VolumeLiquidOptions } from "./unitOptions";
+import { EnergyUnitOptions, MassUnitOptions, PowerUnitOptions, EnergySteamMixedUnitOptions, UnitOption, VolumeGasOptions, VolumeLiquidOptions } from "./unitOptions";
 
 // export type UtilityType = 'Electricity' | 'Natural Gas' | 'Other Fuels' | 'Water' | 'Waste Water' | 'Steam' | 'Compressed Air';
 // export const UtilityTypes: Array<UtilityType> = ['Electricity', 'Natural Gas', 'Other Fuels', 'Water', 'Waste Water', 'Steam', 'Compressed Air'];
@@ -65,7 +65,7 @@ export const UtilityOptions: Array<UtilityOption> = [
     // },
     {
         utilityType: 'Steam',
-        energyUnitOptions: EnergySteamUnitOptions,
+        energyUnitOptions: EnergySteamMixedUnitOptions,
         isStandardEnergyUnit: true,
         powerUnitOptions: PowerUnitOptions,
         energyDefaultUnit: klb,


### PR DESCRIPTION
#272 Variable renaming to avoid confusion to have mass as energy units