### PR TITLE
Issue 264: Maintenance Cost KPI

### DIFF
--- a/src/app/setup-wizard/data-collection/on-site-assessment/neb-forms-accordion/neb-setup-form/performance-metric-impact-form/performance-metric-impact-form.component.html
+++ b/src/app/setup-wizard/data-collection/on-site-assessment/neb-forms-accordion/neb-setup-form/performance-metric-impact-form/performance-metric-impact-form.component.html
@@ -53,12 +53,13 @@
                 </div>
             </div>
         </div>
+        <div class="form-block">
+            <app-kpm-details-form [keyPerformanceMetric]="keyPerformanceMetric"
+                [disableForm]="(metricHasOtherImpacts && !overrideBaseline)" (emitSave)="savePerformanceMetric()"
+                (emitCalculate)="calculateCostFromKPM($event)" [context]="'onSite'"></app-kpm-details-form>
 
-        <ng-template [ngIf]="keyPerformanceMetric.isQuantitative" [ngIfElse]="qualitativeMetricBlock">
-            <div class="form-block">
-                <app-kpm-details-form [keyPerformanceMetric]="keyPerformanceMetric"
-                    [disableForm]="(metricHasOtherImpacts && !overrideBaseline)" (emitSave)="savePerformanceMetric()"
-                    (emitCalculate)="calculateCost()" [context]="'onSite'"></app-kpm-details-form>
+
+            <ng-template [ngIf]="keyPerformanceMetric.isQuantitative">
                 <div class="row">
                     <label class="col-sm-6 col-form-label" for="modificationValue">
                         Impact on KPM
@@ -111,13 +112,8 @@
                         </ng-template>
                     </div>
                 </div>
-            </div>
-        </ng-template>
-        <ng-template #qualitativeMetricBlock>
-            <div class="alert alert-info small">
-                Quantitative results unavailable at this time.
-            </div>
-        </ng-template>
+            </ng-template>
+        </div>
     </div>
 </ng-template>
 <ng-template #missingMetricBlock>

--- a/src/app/setup-wizard/data-collection/on-site-assessment/neb-forms-accordion/neb-setup-form/performance-metric-impact-form/performance-metric-impact-form.component.ts
+++ b/src/app/setup-wizard/data-collection/on-site-assessment/neb-forms-accordion/neb-setup-form/performance-metric-impact-form/performance-metric-impact-form.component.ts
@@ -83,6 +83,14 @@ export class PerformanceMetricImpactFormComponent {
     await this.keyPerformanceMetricImpactIdbService.asyncUpdate(this.keyPerformanceMetricImpact);
   }
 
+  calculateCostFromKPM(kpmChanges: {modifiedMethod: boolean, updateBaseline: boolean}){
+    if(kpmChanges.modifiedMethod){
+      this.keyPerformanceMetricImpact.modificationValue = undefined;
+    }
+    this.calculateCost();
+  }
+
+
   calculateCost() {
     if (this.keyPerformanceMetric.calculationMethod == 'costPerUnit') {
       this.keyPerformanceMetricImpact.costAdjustment = (this.keyPerformanceMetricImpact.modificationValue * this.keyPerformanceMetric.costPerValue);

--- a/src/app/setup-wizard/pre-visit/company-kpi-details/company-kpi-details.component.html
+++ b/src/app/setup-wizard/pre-visit/company-kpi-details/company-kpi-details.component.html
@@ -95,10 +95,34 @@
                                 Associated Key Performance Metrics
                             </div>
                             <div>
-                                <button class="btn btn-outline-metric btn-sm" (click)="addPerformanceMetric()">
-                                    <fa-icon [icon]="faPlus"></fa-icon>
-                                    Add New Metric
-                                </button>
+                                <ng-template [ngIf]="keyPerformanceIndicator.optionValue != 'other'"
+                                    [ngIfElse]="customAddBlock">
+                                    <div class="dropdown">
+                                        <button class="btn btn-outline-metric btn-sm dropdown-toggle" type="button"
+                                            data-bs-toggle="dropdown" aria-expanded="false"
+                                            (click)="toggleAddMetricDropdown()">
+                                            <fa-icon [icon]="faPlus"></fa-icon> Add Performance Metric
+                                        </button>
+                                        <ul class="dropdown-menu" [ngClass]="{'show': showAddMetricDropdown}">
+                                            <li>
+                                                <a class="dropdown-item" (click)="addPerformanceMetric()">
+                                                    <fa-icon [icon]="faPlus"></fa-icon> Add Custom Performance Metric
+                                                </a>
+                                            </li>
+                                            <li>
+                                                <a class="dropdown-item" (click)="showSuggestedMetrics()">
+                                                    <fa-icon [icon]="faSearchPlus"></fa-icon> Search Performance Metric
+                                                </a>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </ng-template>
+                                <ng-template #customAddBlock>
+                                    <button class="btn btn-outline-metric btn-sm" (click)="addPerformanceMetric()">
+                                        <fa-icon [icon]="faPlus"></fa-icon>
+                                        Add Custom Performance Metric
+                                    </button>
+                                </ng-template>
                             </div>
                         </div>
                     </h6>
@@ -245,3 +269,7 @@
         </div>
     </ng-template>
 </div>
+
+
+<app-kpm-database-modal *ngIf="displayAddMetricModal" (emitClose)="closeSuggestedMetrics()"
+    [keyPerformanceIndicator]="keyPerformanceIndicator" (emitAddMetrics)="addMetrics($event)"></app-kpm-database-modal>

--- a/src/app/setup-wizard/pre-visit/company-kpi-details/company-kpi-details.component.ts
+++ b/src/app/setup-wizard/pre-visit/company-kpi-details/company-kpi-details.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { IconDefinition, faBullseye, faChartBar, faChevronLeft, faChevronRight, faCircleQuestion, faClose, faContactBook, faPlus, faScaleUnbalancedFlip, faTrash, faUser } from '@fortawesome/free-solid-svg-icons';
+import { IconDefinition, faBullseye, faChartBar, faChevronLeft, faChevronRight, faCircleQuestion, faClose, faContactBook, faPlus, faScaleUnbalancedFlip, faSearchPlus, faTrash, faUser } from '@fortawesome/free-solid-svg-icons';
 import { IdbOnSiteVisit } from 'src/app/models/onSiteVisit';
 import { OnSiteVisitIdbService } from 'src/app/indexed-db/on-site-visit-idb.service';
 import { CompanyIdbService } from 'src/app/indexed-db/company-idb.service';
@@ -30,6 +30,7 @@ export class CompanyKpiDetailsComponent {
   faContactBook: IconDefinition = faContactBook;
   faClose: IconDefinition = faClose;
   faTrash: IconDefinition = faTrash;
+  faSearchPlus: IconDefinition = faSearchPlus;
 
   keyPerformanceIndicator: IdbKeyPerformanceIndicator;
   primaryKPIs: Array<PrimaryKPI> = PrimaryKPIs;
@@ -61,6 +62,9 @@ export class CompanyKpiDetailsComponent {
 
   timeOptions: Array<string> = ['day', 'week', 'month', 'year'];
   dropdownMenuGuid: string;
+
+  displayAddMetricModal: boolean = false;
+  showAddMetricDropdown: boolean = false;
   constructor(private router: Router,
     private onSiteVisitIdbService: OnSiteVisitIdbService,
     private keyPerformanceIndicatorIdbService: KeyPerformanceIndicatorsIdbService,
@@ -172,6 +176,9 @@ export class CompanyKpiDetailsComponent {
   }
 
   addPerformanceMetric() {
+    if(this.showAddMetricDropdown){
+      this.showAddMetricDropdown = false;
+    }
     let newCustomKPM: KeyPerformanceMetric = getCustomKPM(this.keyPerformanceIndicator.optionValue, this.keyPerformanceIndicator.guid);
     this.keyPerformanceIndicator.performanceMetrics.unshift(newCustomKPM);
     this.saveChanges();
@@ -211,4 +218,27 @@ export class CompanyKpiDetailsComponent {
       this.dropdownMenuGuid = undefined;
     }
   }
+
+  toggleAddMetricDropdown() {
+    this.showAddMetricDropdown = !this.showAddMetricDropdown;
+  }
+
+  showSuggestedMetrics() {
+    if(this.showAddMetricDropdown){
+      this.showAddMetricDropdown = false;
+    }
+    this.displayAddMetricModal = true;
+  }
+
+  closeSuggestedMetrics() {
+    this.displayAddMetricModal = false;
+  }
+
+  addMetrics(metrics: Array<KeyPerformanceMetric>) {
+    metrics.forEach(metric => {
+      this.keyPerformanceIndicator.performanceMetrics.unshift(metric);
+    })
+    this.saveChanges();
+  }
+
 }

--- a/src/app/setup-wizard/pre-visit/company-kpi-details/company-kpi-details.component.ts
+++ b/src/app/setup-wizard/pre-visit/company-kpi-details/company-kpi-details.component.ts
@@ -94,6 +94,7 @@ export class CompanyKpiDetailsComponent {
       let kpiGuid: string = params['id'];
       this.keyPerformanceIndicator = this.keyPerformanceIndicatorIdbService.getByGuid(kpiGuid);
       this.setIndexValues();
+      this.showAddMetricDropdown = false;
     });
   }
 
@@ -176,7 +177,7 @@ export class CompanyKpiDetailsComponent {
   }
 
   addPerformanceMetric() {
-    if(this.showAddMetricDropdown){
+    if (this.showAddMetricDropdown) {
       this.showAddMetricDropdown = false;
     }
     let newCustomKPM: KeyPerformanceMetric = getCustomKPM(this.keyPerformanceIndicator.optionValue, this.keyPerformanceIndicator.guid);
@@ -224,7 +225,7 @@ export class CompanyKpiDetailsComponent {
   }
 
   showSuggestedMetrics() {
-    if(this.showAddMetricDropdown){
+    if (this.showAddMetricDropdown) {
       this.showAddMetricDropdown = false;
     }
     this.displayAddMetricModal = true;

--- a/src/app/setup-wizard/pre-visit/company-kpi-details/kpm-database-modal/kpm-database-modal.component.css
+++ b/src/app/setup-wizard/pre-visit/company-kpi-details/kpm-database-modal/kpm-database-modal.component.css
@@ -1,0 +1,3 @@
+.popup-header{
+    font-weight: normal;
+}

--- a/src/app/setup-wizard/pre-visit/company-kpi-details/kpm-database-modal/kpm-database-modal.component.html
+++ b/src/app/setup-wizard/pre-visit/company-kpi-details/kpm-database-modal/kpm-database-modal.component.html
@@ -1,0 +1,45 @@
+<div [ngClass]="{'window-overlay': displayModal}"></div>
+<div class="popup" [ngClass]="{'open': displayModal }">
+    <div class="popup-header">KPMs Typically Associated With
+        <span class="bold" [innerHTML]="keyPerformanceIndicator.htmlLabel"></span>
+        <button type="button" class="btn-close float-end" aria-label="Close" (click)="closeModal()"></button>
+    </div>
+    <div class="popup-body">
+        <ng-template [ngIf]="keyPerformanceMetricOptions.length > 0" [ngIfElse]="noOptionsBlock">
+            <table class="table table-bordered table-hover table-sm">
+                <tbody>
+                    <tr class="clickable" (click)="toggleMetric(performanceMetric)"
+                        *ngFor="let performanceMetric of keyPerformanceMetricOptions">
+                        <td class="add-td text-center">
+                            <a class="click-link">
+                                <ng-template [ngIf]="addMetricValues.includes(performanceMetric.value)"
+                                    [ngIfElse]="addMetricBlock">
+                                    <fa-icon [icon]="faCheck"></fa-icon>
+                                </ng-template>
+                                <ng-template #addMetricBlock>
+                                    <fa-icon [icon]="faPlus"></fa-icon>
+                                </ng-template>
+                            </a>
+                        </td>
+                        <td>
+                            <span [innerHTML]="performanceMetric.htmlLabel"></span>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </ng-template>
+        <ng-template #noOptionsBlock>
+            <div class="alert alert-info">
+                All metrics in our system that are associated with <span class="bold"
+                    [innerHTML]="keyPerformanceIndicator.htmlLabel"></span> are being tracked.
+            </div>
+        </ng-template>
+        <hr>
+    </div>
+    <div class="popup-footer d-flex justify-content-end">
+        <button class="btn btn-secondary btn-sm me-2" (click)="closeModal()">Cancel</button>
+        <button class="btn btn-sm btn-success" (click)="addMetrics()" [disabled]="addMetricValues.length == 0"><fa-icon
+                [icon]="faPlus"></fa-icon> Add {{addMetricValues.length}}
+            Metrics</button>
+    </div>
+</div>

--- a/src/app/setup-wizard/pre-visit/company-kpi-details/kpm-database-modal/kpm-database-modal.component.spec.ts
+++ b/src/app/setup-wizard/pre-visit/company-kpi-details/kpm-database-modal/kpm-database-modal.component.spec.ts
@@ -1,6 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { KpmDatabaseModalComponent } from './kpm-database-modal.component';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { getNewKeyPerformanceIndicator } from 'src/app/models/keyPerformanceIndicator';
+import { KeyPerformanceIndicatorOption } from 'src/app/shared/constants/keyPerformanceIndicatorOptions';
 
 describe('KpmDatabaseModalComponent', () => {
   let component: KpmDatabaseModalComponent;
@@ -8,12 +11,20 @@ describe('KpmDatabaseModalComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
+      imports: [FontAwesomeModule],
       declarations: [KpmDatabaseModalComponent]
     })
-    .compileComponents();
+      .compileComponents();
 
     fixture = TestBed.createComponent(KpmDatabaseModalComponent);
     component = fixture.componentInstance;
+    let tmpIndicatorOption: KeyPerformanceIndicatorOption = {
+      primaryKPI: 'Operations',
+      label: '',
+      htmlLabel: '',
+      optionValue: 'chemicalEmissions'
+    }
+    component.keyPerformanceIndicator = getNewKeyPerformanceIndicator('', '', tmpIndicatorOption, false)
     fixture.detectChanges();
   });
 

--- a/src/app/setup-wizard/pre-visit/company-kpi-details/kpm-database-modal/kpm-database-modal.component.spec.ts
+++ b/src/app/setup-wizard/pre-visit/company-kpi-details/kpm-database-modal/kpm-database-modal.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { KpmDatabaseModalComponent } from './kpm-database-modal.component';
+
+describe('KpmDatabaseModalComponent', () => {
+  let component: KpmDatabaseModalComponent;
+  let fixture: ComponentFixture<KpmDatabaseModalComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [KpmDatabaseModalComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(KpmDatabaseModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/setup-wizard/pre-visit/company-kpi-details/kpm-database-modal/kpm-database-modal.component.ts
+++ b/src/app/setup-wizard/pre-visit/company-kpi-details/kpm-database-modal/kpm-database-modal.component.ts
@@ -1,0 +1,71 @@
+import { ChangeDetectorRef, Component, EventEmitter, Input, Output } from '@angular/core';
+import { faCheck, faPlus, IconDefinition } from '@fortawesome/free-solid-svg-icons';
+import { IdbKeyPerformanceIndicator } from 'src/app/models/keyPerformanceIndicator';
+import { getPerformanceMetrics, KeyPerformanceMetric, KeyPerformanceMetricValue } from 'src/app/shared/constants/keyPerformanceMetrics';
+
+@Component({
+  selector: 'app-kpm-database-modal',
+  templateUrl: './kpm-database-modal.component.html',
+  styleUrl: './kpm-database-modal.component.css'
+})
+export class KpmDatabaseModalComponent {
+  @Output('emitClose')
+  emitClose: EventEmitter<boolean> = new EventEmitter<boolean>();
+  @Input({ required: true })
+  keyPerformanceIndicator: IdbKeyPerformanceIndicator;
+  @Output()
+  emitAddMetrics: EventEmitter<Array<KeyPerformanceMetric>> = new EventEmitter<Array<KeyPerformanceMetric>>();
+
+  faPlus: IconDefinition = faPlus;
+  faCheck: IconDefinition = faCheck;
+  displayModal: boolean = false;
+
+  keyPerformanceMetricOptions: Array<KeyPerformanceMetric>;
+  addMetricValues: Array<KeyPerformanceMetricValue> = [];
+  constructor(private cd: ChangeDetectorRef) {
+
+  }
+
+  ngOnInit() {
+    let currentTrackedMetrics: Array<KeyPerformanceMetricValue> = this.keyPerformanceIndicator.performanceMetrics.flatMap(metric => {
+      return metric.value;
+    })
+
+    this.keyPerformanceMetricOptions = new Array();
+
+    let tmpKeyPerformanceMetricOptions: Array<KeyPerformanceMetric> = getPerformanceMetrics(this.keyPerformanceIndicator.optionValue, this.keyPerformanceIndicator.guid)
+    tmpKeyPerformanceMetricOptions.forEach(option => {
+      if (currentTrackedMetrics.includes(option.value) == false) {
+        this.keyPerformanceMetricOptions.push(option);
+      }
+    });
+  }
+
+  ngAfterViewInit() {
+    this.displayModal = true;
+    this.cd.detectChanges();
+  }
+
+  closeModal() {
+    this.displayModal = false;
+    this.emitClose.emit(true);
+  }
+
+  toggleMetric(keyPerformanceMetric: KeyPerformanceMetric) {
+    if (this.addMetricValues.includes(keyPerformanceMetric.value)) {
+      this.addMetricValues = this.addMetricValues.filter(value => {
+        return value != keyPerformanceMetric.value
+      });
+    } else {
+      this.addMetricValues.push(keyPerformanceMetric.value);
+    }
+  }
+
+  addMetrics() {
+    let metricsToAdd: Array<KeyPerformanceMetric> = this.keyPerformanceMetricOptions.filter(option => {
+      return this.addMetricValues.includes(option.value)
+    })
+    this.emitAddMetrics.emit(metricsToAdd);
+    this.closeModal();
+  }
+}

--- a/src/app/setup-wizard/setup-wizard.module.ts
+++ b/src/app/setup-wizard/setup-wizard.module.ts
@@ -62,6 +62,7 @@ import { SetupWizardHelpPanelModule } from './setup-wizard-help-panel/setup-wiza
 import { LabelWithTooltipModule } from '../shared/label-with-tooltip/label-with-tooltip.module';
 import { KpmDetailsFormModule } from '../shared/kpm-details-form/kpm-details-form.module';
 import { KpiDescriptionPipe } from './pre-visit/company-kpi-details/kpi-description.pipe';
+import { KpmDatabaseModalComponent } from './pre-visit/company-kpi-details/kpm-database-modal/kpm-database-modal.component';
 
 @NgModule({
   declarations: [
@@ -114,7 +115,8 @@ import { KpiDescriptionPipe } from './pre-visit/company-kpi-details/kpi-descript
     KpmImpactsTableComponent,
     EnergyOpportunityNebsTableComponent,
     EnergyOpportunityNebsListPipe,
-    KpiDescriptionPipe
+    KpiDescriptionPipe,
+    KpmDatabaseModalComponent
   ],
   imports: [
     CommonModule,

--- a/src/app/shared/constants/keyPerformanceIndicatorOptions.ts
+++ b/src/app/shared/constants/keyPerformanceIndicatorOptions.ts
@@ -19,6 +19,7 @@ export type KeyPerformanceIndicatorValue =
     'improveSpaceUtilization' |
     'employeeEngagementWorkforceDevelopment' |
     'employeeEngagementWorkingEnvironment' | 
+    'maintenanceExpense' |
     'other';
 
 export interface KeyPerformanceIndicatorOption {
@@ -136,5 +137,11 @@ export const KeyPerformanceIndicatorOptions: Array<KeyPerformanceIndicatorOption
         label: 'Employee Engagement - Workforce Development',
         htmlLabel: 'Employee Engagement - Workforce Development',
         optionValue: 'employeeEngagementWorkforceDevelopment'
+    },
+    {
+        primaryKPI: 'Operations',
+        label: 'Maintenance Expense',
+        htmlLabel: 'Maintenance Expense',
+        optionValue: 'maintenanceExpense'
     },
 ]

--- a/src/app/shared/constants/keyPerformanceIndicatorOptions.ts
+++ b/src/app/shared/constants/keyPerformanceIndicatorOptions.ts
@@ -68,8 +68,8 @@ export const KeyPerformanceIndicatorOptions: Array<KeyPerformanceIndicatorOption
     },
     {
         primaryKPI: 'Operations',
-        label: 'Reduce Expense Cost',
-        htmlLabel: 'Reduce Expense Cost',
+        label: 'Expense Cost',
+        htmlLabel: 'Expense Cost',
         optionValue: 'reduceExpenseCost'
     },
     {

--- a/src/app/shared/constants/keyPerformanceMetrics.ts
+++ b/src/app/shared/constants/keyPerformanceMetrics.ts
@@ -128,8 +128,7 @@ export interface KeyPerformanceMetricOption {
     totalUnit?: string,
     goalToIncrease: boolean,
     timePeriod: string,
-    calculationMethod?: KpmCalculationMethod,
-    quantitativeUnavailable?: boolean
+    calculationMethod?: KpmCalculationMethod
 };
 
 
@@ -177,8 +176,7 @@ export const KeyPerformanceMetricOptions: Array<KeyPerformanceMetricOption> = [
         kpiValue: "strategicRelationshipImpact",
         isQuantitative: false,
         goalToIncrease: true,
-        timePeriod: 'yr',
-        quantitativeUnavailable: true
+        timePeriod: 'yr'
     },
     {
         label: "Lost Customer Sales ($)",
@@ -198,8 +196,7 @@ export const KeyPerformanceMetricOptions: Array<KeyPerformanceMetricOption> = [
         kpiValue: "strategicRelationshipImpact",
         isQuantitative: false,
         goalToIncrease: true,
-        timePeriod: 'yr',
-        quantitativeUnavailable: true
+        timePeriod: 'yr'
     },
     {
         label: "Supplier Satisfaction Ratings",
@@ -208,8 +205,7 @@ export const KeyPerformanceMetricOptions: Array<KeyPerformanceMetricOption> = [
         kpiValue: "strategicRelationshipImpact",
         isQuantitative: false,
         goalToIncrease: true,
-        timePeriod: 'yr',
-        quantitativeUnavailable: true
+        timePeriod: 'yr'
     },
     {
         label: "Productivity rate: Throughput",
@@ -218,8 +214,7 @@ export const KeyPerformanceMetricOptions: Array<KeyPerformanceMetricOption> = [
         kpiValue: "productivity",
         isQuantitative: false,
         goalToIncrease: true,
-        timePeriod: 'yr',
-        quantitativeUnavailable: true
+        timePeriod: 'yr'
     },
     {
         label: "Production Costs",
@@ -386,8 +381,7 @@ export const KeyPerformanceMetricOptions: Array<KeyPerformanceMetricOption> = [
         kpiValue: "quality",
         isQuantitative: false,
         goalToIncrease: true,
-        timePeriod: 'yr',
-        quantitativeUnavailable: true
+        timePeriod: 'yr'
     },
     {
         label: "$ Customer Returns (quality)",

--- a/src/app/shared/constants/keyPerformanceMetrics.ts
+++ b/src/app/shared/constants/keyPerformanceMetrics.ts
@@ -98,6 +98,12 @@ export type KeyPerformanceMetricValue =
     'employeeRetentionRate' |
     'talentTurnoverRate' |
     'totalLbsDust' |
+    'laborCosts' |
+    'thirdPartyLabor' |
+    'serviceParts' |
+    'treatmentChemicals' |
+    'rawMaterials' |
+    'intermediateGoods' |
     'custom';
 
 
@@ -440,7 +446,7 @@ export const KeyPerformanceMetricOptions: Array<KeyPerformanceMetricOption> = [
         label: "Maintenance Cost",
         htmlLabel: "Maintenance Cost",
         value: "maintenanceCost",
-        kpiValue: "reduceExpenseCost",
+        kpiValue: "maintenanceExpense",
         isQuantitative: true,
         totalUnit: 'hr',
         goalToIncrease: false,
@@ -451,7 +457,7 @@ export const KeyPerformanceMetricOptions: Array<KeyPerformanceMetricOption> = [
         label: "Engineering support (dollars or hours)",
         htmlLabel: "Engineering support (&#36; or hours)",
         value: "engineeringSupport",
-        kpiValue: "reduceExpenseCost",
+        kpiValue: "maintenanceExpense",
         isQuantitative: true,
         totalUnit: 'hr',
         goalToIncrease: false,
@@ -684,6 +690,72 @@ export const KeyPerformanceMetricOptions: Array<KeyPerformanceMetricOption> = [
         value: "talentTurnoverRate",
         kpiValue: "employeeEngagementWorkforceDevelopment",
         isQuantitative: true,
+        goalToIncrease: false,
+        timePeriod: 'yr',
+        calculationMethod: 'directCost'
+    },
+    {
+        label: "Labor Costs",
+        htmlLabel: "Labor Costs",
+        value: "laborCosts",
+        kpiValue: "maintenanceExpense",
+        isQuantitative: true,
+        totalUnit: 'hr',
+        goalToIncrease: false,
+        timePeriod: 'yr',
+        calculationMethod: 'costPerUnit'
+    },
+    {
+        label: "3rd Party Labor",
+        htmlLabel: "3rd Party Labor",
+        value: "thirdPartyLabor",
+        kpiValue: "maintenanceExpense",
+        isQuantitative: true,
+        totalUnit: 'hr',
+        goalToIncrease: false,
+        timePeriod: 'yr',
+        calculationMethod: 'costPerUnit'
+    },
+    {
+        label: "Service Parts",
+        htmlLabel: "Service Parts",
+        value: "serviceParts",
+        kpiValue: "reduceExpenseCost",
+        isQuantitative: true,
+        totalUnit: 'parts',
+        goalToIncrease: false,
+        timePeriod: 'yr',
+        calculationMethod: 'costPerUnit'
+    },
+    {
+        label: "Treatment Chemicals",
+        htmlLabel: "Treatment Chemicals",
+        value: "treatmentChemicals",
+        kpiValue: "reduceExpenseCost",
+        isQuantitative: true,
+        totalUnit: '',
+        goalToIncrease: false,
+        timePeriod: 'yr',
+        calculationMethod: 'directCost'
+    },
+    {
+        label: "Raw Materials",
+        htmlLabel: "Raw Materials",
+        value: "rawMaterials",
+        kpiValue: "reduceExpenseCost",
+        isQuantitative: true,
+        totalUnit: '',
+        goalToIncrease: false,
+        timePeriod: 'yr',
+        calculationMethod: 'directCost'
+    },
+    {
+        label: "Intermediate Goods",
+        htmlLabel: "Intermediate Goods",
+        value: "intermediateGoods",
+        kpiValue: "reduceExpenseCost",
+        isQuantitative: true,
+        totalUnit: '',
         goalToIncrease: false,
         timePeriod: 'yr',
         calculationMethod: 'directCost'

--- a/src/app/shared/kpm-details-form/kpm-details-form.component.html
+++ b/src/app/shared/kpm-details-form/kpm-details-form.component.html
@@ -1,4 +1,4 @@
-<div class="row" *ngIf="!keyPerformanceMetric.quantitativeUnavailable">
+<div class="row">
     <label class="col-sm-6 col-form-label" for="{{'isQuantitative_'+keyPerformanceMetric.value}}">
         Metric Type
     </label>
@@ -35,13 +35,15 @@
             Calculation Method
         </label> -->
         <div class="col-sm-6 col-form-label">
-            <app-label-with-tooltip [field]="'calculationMethod'" [labelId]="'calculationMethod_'+keyPerformanceMetric.value"
+            <app-label-with-tooltip [field]="'calculationMethod'"
+                [labelId]="'calculationMethod_'+keyPerformanceMetric.value"
                 [label]="'Impact Calculation Method'"></app-label-with-tooltip>
         </div>
         <div class="col-6">
             <select id="{{'calculationMethod_'+keyPerformanceMetric.value}}"
                 name="{{'calculationMethod_'+keyPerformanceMetric.value}}" class="form-select"
-                [(ngModel)]="keyPerformanceMetric.calculationMethod" (change)="saveChanges()" [disabled]="disableForm">
+                [(ngModel)]="keyPerformanceMetric.calculationMethod" (change)="calculateCost(true)"
+                [disabled]="disableForm">
                 <option [ngValue]="'costPerUnit'">Cost Per Unit</option>
                 <option [ngValue]="'directCost'">Direct Cost</option>
                 <option [ngValue]="'percentTotal'">Percent Total</option>
@@ -86,7 +88,7 @@
             <div class="col-6">
                 <div class="input-group">
                     <input type="number" class="form-control" [(ngModel)]="keyPerformanceMetric.baselineValue"
-                        name="{{'baselineValue_'+keyPerformanceMetric.value}}" (input)="calculateCost()"
+                        name="{{'baselineValue_'+keyPerformanceMetric.value}}" (input)="calculateCost(false)"
                         [disabled]="disableForm">
                     <span class="input-group-text">
                         <span [innerHTML]="keyPerformanceMetric.totalUnit | unitsDisplay"></span>/yr
@@ -105,7 +107,7 @@
             <div class="col-6">
                 <div class="input-group">
                     <input type="number" class="form-control" [(ngModel)]="keyPerformanceMetric.costPerValue"
-                        name="{{'costPerValue_'+keyPerformanceMetric.value}}" (input)="calculateCost()"
+                        name="{{'costPerValue_'+keyPerformanceMetric.value}}" (input)="calculateCost(false)"
                         [disabled]="disableForm">
                     <span class="input-group-text">
                         &dollar;/<span [innerHTML]="keyPerformanceMetric.totalUnit | unitsDisplay"></span>
@@ -137,7 +139,7 @@
             <div class="col-6">
                 <div class="input-group">
                     <input type="number" class="form-control" [(ngModel)]="keyPerformanceMetric.baselineCost"
-                        name="{{'baselineCost_'+keyPerformanceMetric.value}}" (input)="calculateCost()"
+                        name="{{'baselineCost_'+keyPerformanceMetric.value}}" (input)="calculateCost(false)"
                         [disabled]="disableForm">
                     <span class="input-group-text">
                         &dollar;/yr
@@ -146,9 +148,4 @@
             </div>
         </div>
     </ng-template>
-</ng-template>
-<ng-template [ngIf]="keyPerformanceMetric.quantitativeUnavailable">
-    <div class="alert alert-info small mt-2">
-        Quantitative results unavailable at this time.
-    </div>
 </ng-template>

--- a/src/app/shared/kpm-details-form/kpm-details-form.component.ts
+++ b/src/app/shared/kpm-details-form/kpm-details-form.component.ts
@@ -14,7 +14,7 @@ export class KpmDetailsFormComponent {
   @Output('emitSave')
   emitSave: EventEmitter<boolean> = new EventEmitter();
   @Output('emitCalculate')
-  emitCalculate: EventEmitter<boolean> = new EventEmitter();
+  emitCalculate: EventEmitter<{modifiedMethod: boolean, updateBaseline: boolean}> = new EventEmitter();
   @Input({required: true})
   context: 'preVisit' | 'onSite';
 
@@ -23,13 +23,13 @@ export class KpmDetailsFormComponent {
     this.emitSave.emit(true);
   }
 
-  calculateCost() {
+  calculateCost(modifiedMethod: boolean) {
     if (this.keyPerformanceMetric.calculationMethod == 'costPerUnit') {
       this.keyPerformanceMetric.baselineCost = (this.keyPerformanceMetric.costPerValue * this.keyPerformanceMetric.baselineValue);
     }
-    this.emitCalculate.emit(true);
-    if (this.context == 'onSite') {
-      this.saveChanges();
-    }
+    this.emitCalculate.emit({modifiedMethod: modifiedMethod, updateBaseline: true});
+    // if (this.context == 'onSite') {
+    //   this.saveChanges();
+    // }
   }
 }


### PR DESCRIPTION
connects #264 
connects #301 (accidentally pushed my changes for 301 to this PR)

Move's KPMs from "Expense Cost" to new KPI for "Maintenance Cost"
Adds new KPMs to "Expense Cost" from Bruce
Remove "Qualitative Unavailable" from metrics. Allows all metrics to be set to qualitative.
Fixes bug when changing calculation method for KPMs (301)

Adds modal for users to add back KPMs they have deleted or new ones that have been added to the system after data has been entered.

