### PR TITLE
fix to the confusion of utility / energy in cost saving table

### DIFF
--- a/src/app/shared/reports/assessment-report/assessment-savings-table/assessment-savings-table.component.html
+++ b/src/app/shared/reports/assessment-report/assessment-savings-table/assessment-savings-table.component.html
@@ -15,13 +15,13 @@
     <tbody>
         <tr>
             <td class="bold" colspan="3">
-                Baseline
+                Assessment Baseline
             </td>
         </tr>
         <tr>
             <td class="w-50 ps-3">
                 <!-- Baseline -->
-                Energy Use
+                Energy Related Use
             </td>
             <td class="text-right">
                 <app-single-cell-item [numValue]="assessmentReport.assessment.energyCost"
@@ -34,15 +34,15 @@
             </td>
         </tr>
         <tr>
-            <td class="w-50 ps-3">
+            <td class="w-50 ps-3 bold">
                 <!-- Baseline -->
-                Utility Use
+                Assessment Total Utility Use
             </td>
-            <td class="text-right">
+            <td class="text-right bold">
                 <app-single-cell-item [numValue]="assessmentReport.assessment.cost"
                     [isCurrency]="true" [negativeNumber]="true"></app-single-cell-item>
             </td>
-            <td class="text-right">
+            <td class="text-right bold">
                 <app-single-cell-item [numValue]="0"
                     [isCurrency]="false"></app-single-cell-item>
             </td>
@@ -54,6 +54,19 @@
         </tr>
         <tr>
             <td class="w-50 ps-3">
+                 Assessment Total Utility Savings
+            </td>
+            <td class="text-right">
+                <app-single-cell-item [numValue]="assessmentReport.assessment.costSavings"
+                    [isCurrency]="true"></app-single-cell-item>
+            </td>
+            <td class="text-right">
+                &mdash;
+            </td>
+        </tr>
+        <tr>
+            <td class="ps-4">
+                <fa-icon class="pe-1" [icon]="faPlugCircleBolt"></fa-icon>
                 Assessment Energy Savings
             </td>
             <td class="text-right">
@@ -65,25 +78,13 @@
                     [isCurrency]="false" [units]="companyEnergyUnit"></app-single-cell-item>
             </td>
         </tr>
-        <tr>
-            <td class="w-50 ps-3">
-                 Assessment Utility Savings
-            </td>
-            <td class="text-right">
-                <app-single-cell-item [numValue]="assessmentReport.assessment.costSavings"
-                    [isCurrency]="true"></app-single-cell-item>
-            </td>
-            <td class="text-right">
-                &mdash;
-            </td>
-        </tr>
         <tr *ngIf="assessmentReport.assessmentNebReports.length > 0">
             <td colspan="3" class="ps-3">
                 Additional Operational Benefits
             </td>
         </tr>
         <tr *ngFor="let nebReport of assessmentReport.assessmentNebReports">
-            <td class="ps-5">
+            <td class="ps-4">
                 <fa-icon class="pe-1" [icon]="faWeightHanging"></fa-icon>
                 {{nebReport.nonEnergyBenefit.name}}
             </td>

--- a/src/app/shared/reports/assessment-report/assessment-savings-table/assessment-savings-table.component.ts
+++ b/src/app/shared/reports/assessment-report/assessment-savings-table/assessment-savings-table.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core';
-import { IconDefinition, faFileLines, faScrewdriverWrench, faWeightHanging } from '@fortawesome/free-solid-svg-icons';
+import { IconDefinition, faFileLines, faScrewdriverWrench, faWeightHanging, faPlugCircleBolt } from '@fortawesome/free-solid-svg-icons';
 import { AssessmentReport } from '../../calculations/assessmentReport';
 import { LocaleService } from 'src/app/shared/shared-services/locale.service';
 import { Subscription } from 'rxjs';
@@ -19,6 +19,7 @@ export class AssessmentSavingsTableComponent {
   faWeightHanging: IconDefinition = faWeightHanging;
   faScrewdriverWrench: IconDefinition = faScrewdriverWrench;
   faFileLines: IconDefinition = faFileLines;
+  faPlugCircleBolt: IconDefinition = faPlugCircleBolt;
 
   currencyCode: string;
   currencySub: Subscription;

--- a/src/styles.css
+++ b/src/styles.css
@@ -13,6 +13,7 @@
     --contact-color: #5b2c6f;
     --energy-equipment-color: #117a65;
     --kpi-color:#0212b5;
+    --energy-utility-color: #ffa200;
 }
 
 
@@ -165,6 +166,10 @@
 
 .fa-bullseye{
     color: var(--kpi-color);
+}
+
+.fa-plug-circle-bolt{
+    color: var(--energy-utility-color);
 }
 
 .neb-button {


### PR DESCRIPTION
this connects to #456 

- adjust the wording of row name
- add icon to indicate the relationship
- align indentation with other sub-items