### PR TITLE
fix infinite loop issue in payback chart

### DIFF
--- a/src/app/shared/reports/payback-waterfall-chart/payback-waterfall-chart.component.ts
+++ b/src/app/shared/reports/payback-waterfall-chart/payback-waterfall-chart.component.ts
@@ -72,7 +72,10 @@ export class PaybackWaterfallChartComponent {
       let yVals = [implementationCost];
       let yValsNebs = [implementationCost];
       let year = 1;
-      this.years = Math.ceil(this.reportData.totalImplementationCost / this.reportData.totalNonNebCostSavings);
+      this.years = Math.ceil(this.reportData.totalImplementationCost / this.reportData.totalNonNebCostSavings);      
+      if(this.years == Infinity || this.years > 15 || isNaN(this.years)){
+        this.years = 15;
+      }
       for (let i = 0; i < this.years; i++) {
         xVals.push('Year ' + year);
         yVals.push(this.reportData.totalNonNebCostSavings)


### PR DESCRIPTION
introduced in #442 

infinite loop was showing up when calculating payback period years, added guard for that or if the years was too high for the chart to be useful