### PR TITLE
hot fix - update top limit to filtered kpis

### DIFF
--- a/src/app/shared/reports/executive-summary-report/executive-summary-kpi-impacts/executive-summary-kpi-impacts.component.ts
+++ b/src/app/shared/reports/executive-summary-report/executive-summary-kpi-impacts/executive-summary-kpi-impacts.component.ts
@@ -110,6 +110,7 @@ export class ExecutiveSummaryKpiImpactsComponent {
     this.kpiReportRevenueItems = this.kpiReportItems.filter(item => {
       return item.revenue > 0
     });
+    this.limitOptions = Array.from({ length: Math.max(this.kpiReportCostItems.length, this.kpiReportRevenueItems.length) }, (_, i) => i + 1);
     this.orderReportItems();
   }
 


### PR DESCRIPTION
update the upper limit of top kpi impacts to filtered list (max of the lengths of positive cost saving kpis and positive revenue kpis)