### PR TITLE
Issue 556: remove energy cost per unit as associated KPM option

### DIFF
--- a/src/app/shared/constants/nonEnergyBenefitOptions.ts
+++ b/src/app/shared/constants/nonEnergyBenefitOptions.ts
@@ -425,7 +425,7 @@ export const NebOptions: Array<NebOption> = [
         optionValue: "improvedThermalComfort",
         isQualitative: true,
         howToCalculate: "N/A",
-        KPM: ["energyCostPerUnit", "workspaceOrFactoryFloorComfort", "absenteeism", "employeeEngagementSatisfaction", "employeeRetentionRate", "talentTurnoverRate"],
+        KPM: ["workspaceOrFactoryFloorComfort", "absenteeism", "employeeEngagementSatisfaction", "employeeRetentionRate", "talentTurnoverRate"],
         selectedKPM: []
     },
     {
@@ -434,7 +434,7 @@ export const NebOptions: Array<NebOption> = [
         optionValue: "reduceUnscheduledBreaks",
         isQualitative: true,
         howToCalculate: "N/A",
-        KPM: ["energyCostPerUnit", "workspaceOrFactoryFloorComfort", "absenteeism", "employeeEngagementSatisfaction", "employeeRetentionRate", "talentTurnoverRate"],
+        KPM: ["workspaceOrFactoryFloorComfort", "absenteeism", "employeeEngagementSatisfaction", "employeeRetentionRate", "talentTurnoverRate"],
         selectedKPM: []
     },
     {
@@ -443,7 +443,7 @@ export const NebOptions: Array<NebOption> = [
         optionValue: "reduceWorkplaceIncidentsRelatedToHeat",
         isQualitative: true,
         howToCalculate: "N/A",
-        KPM: ["energyCostPerUnit", "workspaceOrFactoryFloorComfort", "absenteeism", "employeeEngagementSatisfaction", "employeeRetentionRate", "talentTurnoverRate"],
+        KPM: ["workspaceOrFactoryFloorComfort", "absenteeism", "employeeEngagementSatisfaction", "employeeRetentionRate", "talentTurnoverRate"],
         selectedKPM: []
     },
     {
@@ -452,7 +452,7 @@ export const NebOptions: Array<NebOption> = [
         optionValue: "increaseWorkplaceSecurity",
         isQualitative: true,
         howToCalculate: "N/A",
-        KPM: ["energyCostPerUnit", "workspaceOrFactoryFloorComfort", "absenteeism", "employeeEngagementSatisfaction", "employeeRetentionRate", "talentTurnoverRate"],
+        KPM: ["workspaceOrFactoryFloorComfort", "absenteeism", "employeeEngagementSatisfaction", "employeeRetentionRate", "talentTurnoverRate"],
         selectedKPM: []
     },
     {


### PR DESCRIPTION
connects #556

was showing up blank in NEB modal. Energy cost savings are not a KPM we track, treated as inherit metric within the tool.