### PR TITLE
Issue 601: fix logic for adding kpm impacts

### DIFF
--- a/src/app/indexed-db/key-performance-indicators-idb.service.ts
+++ b/src/app/indexed-db/key-performance-indicators-idb.service.ts
@@ -80,20 +80,37 @@ export class KeyPerformanceIndicatorsIdbService {
     });
   }
 
-  async addKpmToKpi(companyId: string, performanceMetricToAdd: KeyPerformanceMetric | KeyPerformanceMetricOption, userId: string, facilityId: string): Promise<KeyPerformanceMetric> {
+  async addKpmToKpi(companyId: string, performanceMetricToAdd: KeyPerformanceMetric, userId: string, facilityId: string): Promise<KeyPerformanceMetric> {
     let addedMetric: KeyPerformanceMetric;
-    let keyPerformanceIndicator: IdbKeyPerformanceIndicator = this.getKpiFromKpm(facilityId, performanceMetricToAdd.kpiValue);
+    let keyPerformanceIndicator: IdbKeyPerformanceIndicator;
+    if (performanceMetricToAdd.kpiGuid) {
+      keyPerformanceIndicator = this.getByGuid(performanceMetricToAdd.kpiGuid);
+    } else {
+      keyPerformanceIndicator = this.getKpiFromKpm(facilityId, performanceMetricToAdd.kpiValue);
+    }
     if (keyPerformanceIndicator) {
       //check metric is being tracked in existing KPI
-      addedMetric = keyPerformanceIndicator.performanceMetrics.find(_metric => {
-        return (_metric.value == performanceMetricToAdd.value);
-      });
+      if (performanceMetricToAdd.guid) {
+        addedMetric = keyPerformanceIndicator.performanceMetrics.find(_metric => {
+          return (_metric.guid == performanceMetricToAdd.guid);
+        });
+      } else {
+        addedMetric = keyPerformanceIndicator.performanceMetrics.find(_metric => {
+          return (_metric.value == performanceMetricToAdd.value);
+        });
+      }
       if (!addedMetric) {
         //if not being tracked. Add metric to existing KPI
         let metrics: Array<KeyPerformanceMetric> = getPerformanceMetrics(keyPerformanceIndicator.optionValue, keyPerformanceIndicator.guid);
-        addedMetric = metrics.find(_metric => {
-          return (_metric.value == performanceMetricToAdd.value);
-        });
+        if (performanceMetricToAdd.guid) {
+          addedMetric = metrics.find(_metric => {
+            return (_metric.guid == performanceMetricToAdd.guid);
+          });
+        } else {
+          addedMetric = metrics.find(_metric => {
+            return (_metric.value == performanceMetricToAdd.value);
+          });
+        }
         if (addedMetric) {
           keyPerformanceIndicator.performanceMetrics.push(addedMetric);
           await this.asyncUpdate(keyPerformanceIndicator);
@@ -105,9 +122,17 @@ export class KeyPerformanceIndicatorsIdbService {
         return option.optionValue == performanceMetricToAdd.kpiValue
       });
       keyPerformanceIndicator = getNewKeyPerformanceIndicator(userId, companyId, kpiOption, false, facilityId);
-      addedMetric = keyPerformanceIndicator.performanceMetrics.find(_metric => {
-        return (_metric.value == performanceMetricToAdd.value);
-      });
+
+      //check metric is being tracked in existing KPI
+      if (performanceMetricToAdd.guid) {
+        addedMetric = keyPerformanceIndicator.performanceMetrics.find(_metric => {
+          return (_metric.guid == performanceMetricToAdd.guid);
+        });
+      } else {
+        addedMetric = keyPerformanceIndicator.performanceMetrics.find(_metric => {
+          return (_metric.value == performanceMetricToAdd.value);
+        });
+      }
       await firstValueFrom(this.addWithObservable(keyPerformanceIndicator));
       await this.setKeyPerformanceIndicators();
     }

--- a/src/app/shared/shared-assessment-forms/add-nebs-modal/add-nebs-modal.component.ts
+++ b/src/app/shared/shared-assessment-forms/add-nebs-modal/add-nebs-modal.component.ts
@@ -10,7 +10,7 @@ import { IdbAssessment } from 'src/app/models/assessment';
 import { IdbEnergyOpportunity } from 'src/app/models/energyOpportunity';
 import { getNewIdbKeyPerformanceMetricImpact, IdbKeyPerformanceMetricImpact } from 'src/app/models/keyPerformanceMetricImpact';
 import { IdbNonEnergyBenefit, getNewIdbNonEnergyBenefit } from 'src/app/models/nonEnergyBenefit';
-import { KeyPerformanceMetric, KeyPerformanceMetricOption, KeyPerformanceMetricOptions } from 'src/app/shared/constants/keyPerformanceMetrics';
+import { convertOptionTypeToMetricType, KeyPerformanceMetric, KeyPerformanceMetricOption, KeyPerformanceMetricOptions } from 'src/app/shared/constants/keyPerformanceMetrics';
 import { NebOption, NebOptions } from 'src/app/shared/constants/nonEnergyBenefitOptions';
 import { SharedDataService } from '../../shared-services/shared-data.service';
 import { IdbKeyPerformanceIndicator } from 'src/app/models/keyPerformanceIndicator';
@@ -67,7 +67,8 @@ export class AddNebsModalComponent {
       }
       for (let kpm of nebOption.selectedKPM) {
         let performanceMetricToAdd: KeyPerformanceMetricOption = KeyPerformanceMetricOptions.find(kpmOption => { return kpmOption.value == kpm })
-        let addedMetric: KeyPerformanceMetric = await this.keyPerformanceIndicatorIdbService.addKpmToKpi(newIdbNonEnergyBenefit.companyId, performanceMetricToAdd, newIdbNonEnergyBenefit.userId, newIdbNonEnergyBenefit.facilityId);
+        let keyPerformanceMetric: KeyPerformanceMetric = convertOptionTypeToMetricType(performanceMetricToAdd)
+        let addedMetric: KeyPerformanceMetric = await this.keyPerformanceIndicatorIdbService.addKpmToKpi(newIdbNonEnergyBenefit.companyId, keyPerformanceMetric, newIdbNonEnergyBenefit.userId, newIdbNonEnergyBenefit.facilityId);
         let keyPerformanceIndicator: IdbKeyPerformanceIndicator = this.keyPerformanceIndicatorIdbService.getKpiFromKpm(newIdbNonEnergyBenefit.facilityId, performanceMetricToAdd.kpiValue);
         let newKeyPerformanceMetricImpact: IdbKeyPerformanceMetricImpact = getNewIdbKeyPerformanceMetricImpact(newIdbNonEnergyBenefit.userId, newIdbNonEnergyBenefit.companyId, newIdbNonEnergyBenefit.facilityId, newIdbNonEnergyBenefit.energyOpportunityId, newIdbNonEnergyBenefit.guid, addedMetric.value, newIdbNonEnergyBenefit.assessmentId, keyPerformanceIndicator.guid, addedMetric.guid);
         await firstValueFrom(this.keyPerformanceMetricImpactsIdbService.addWithObservable(newKeyPerformanceMetricImpact));


### PR DESCRIPTION
connects #601 

using the metric value property was causing the tool to only add the first custom kpm. Using the guid when searching from the metric modal fixes the issue.

using value as a fallback when adding from the neb modal, custom kpms will not be added from this modal so won't cause any issues. 