### PR TITLE
Issue 554: give list of KPMs on first pass

### DIFF
--- a/src/app/models/keyPerformanceIndicator.ts
+++ b/src/app/models/keyPerformanceIndicator.ts
@@ -22,6 +22,6 @@ export function getNewKeyPerformanceIndicator(userId: string, companyId: string,
         ...keyPerformanceIndicatorOption,
         isCustom: isCustom,
         description: undefined,
-        performanceMetrics: getPerformanceMetrics(keyPerformanceIndicatorOption.optionValue, idbEntry.guid)
+        performanceMetrics: []
     }
 }

--- a/src/app/shared/shared-facility-forms/kpi-details-form/kpi-details-form.component.css
+++ b/src/app/shared/shared-facility-forms/kpi-details-form/kpi-details-form.component.css
@@ -1,0 +1,7 @@
+.darkgrey{
+    color: darkgrey;
+}
+
+.clickable:hover{
+    cursor: pointer;
+}

--- a/src/app/shared/shared-facility-forms/kpi-details-form/kpi-details-form.component.html
+++ b/src/app/shared/shared-facility-forms/kpi-details-form/kpi-details-form.component.html
@@ -172,11 +172,58 @@
             </div>
         </ng-container>
     </ng-template>
+    <!--NO KPMS SELECTED FOR KPI-->
     <ng-template #noKpmsBlock>
-        <div class="alert alert-info text-center">
-            No perfromance metrics connected to this KPI. Click "<fa-icon [icon]="faPlus"></fa-icon>
-            Add New Metric" to add a new performance metric.
-        </div>
+        <ng-template [ngIf]="keyPerformanceMetricOptions.length > 0" [ngIfElse]="noOptionsBlock">
+            <div class="alert alert-info text-center p-1 small">
+                No performance metrics are connected to this KPI. JUSTIFI has a preset list of related KPMs provided below. Select the
+                metrics you would like to track for this KPI. Click "<fa-icon [icon]="faPlus"></fa-icon>" to select the
+                metrics and then use the "Add Metrics" button to add the metrics to this KPI. Use the dropdown above to
+                add custom metrics if none of the items listed below meet your needs.
+            </div>
+            <table class="table table-bordered table-hover table-sm">
+                <tbody>
+                    <tr class="clickable" (click)="toggleMetric(performanceMetric)"
+                        *ngFor="let performanceMetric of keyPerformanceMetricOptions">
+                        <td class="add-td text-center">
+                            <a class="click-link">
+                                <ng-template [ngIf]="addMetricValues.includes(performanceMetric.value)"
+                                    [ngIfElse]="addMetricBlock">
+                                    <fa-icon [icon]="faCheck"></fa-icon>
+                                </ng-template>
+                                <ng-template #addMetricBlock>
+                                    <fa-icon [icon]="faPlus"></fa-icon>
+                                </ng-template>
+                            </a>
+                        </td>
+                        <td>
+                            <span [innerHTML]="performanceMetric.htmlLabel"></span>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            <div *ngIf="usedPerformanceMetrics.length > 0" class="alert alert-warning small p-1">
+                Some metrics are already in use by another KPI and cannot be added again:
+                <ul class="mb-0">
+                    <li *ngFor="let metric of usedPerformanceMetrics" [innerHTML]="metric.htmlLabel"></li>
+                </ul>
+            </div>
+            <div class="d-flex w-100 justify-content-end">
+                <div>
+                    <button class="btn btn-outline-success btn-sm" [disabled]="addMetricValues.length == 0"
+                        (click)="addInitialMetrics()">Add Metrics</button>
+                </div>
+            </div>
+        </ng-template>
+        <ng-template #noOptionsBlock>
+            <div class="alert alert-info text-center p-1">
+                No performance metrics connected to this KPI. Click "<fa-icon [icon]="faPlus"></fa-icon>" to select the
+                metrics and then use the "Add Metrics" button to add the metrics to this KPI.
+            </div>
+        </ng-template>
+
+
+
     </ng-template>
 </form>
 

--- a/src/app/shared/shared-facility-forms/kpi-details-form/kpi-details-form.component.html
+++ b/src/app/shared/shared-facility-forms/kpi-details-form/kpi-details-form.component.html
@@ -200,14 +200,20 @@
                             <span [innerHTML]="performanceMetric.htmlLabel"></span>
                         </td>
                     </tr>
+                    <tr *ngFor="let performanceMetric of usedPerformanceMetrics">
+                        <td class="darkgrey text-center">
+                            <fa-icon [icon]="faLinkSlash"></fa-icon>
+                        </td>
+                        <td class="darkgrey">
+                            <span [innerHTML]="performanceMetric.htmlLabel"></span>
+                        </td>
+                    </tr>
                 </tbody>
             </table>
-            <div *ngIf="usedPerformanceMetrics.length > 0" class="alert alert-warning small p-1">
-                Some metrics are already in use by another KPI and cannot be added again:
-                <ul class="mb-0">
-                    <li *ngFor="let metric of usedPerformanceMetrics" [innerHTML]="metric.htmlLabel"></li>
-                </ul>
-            </div>
+            <p *ngIf="usedPerformanceMetrics.length > 0" class="fw-light small mb-0">
+                <fa-icon [icon]="faLinkSlash"></fa-icon> Indicates metric is in use by another KPI and cannot be
+                duplicated here.
+            </p>
             <div class="d-flex w-100 justify-content-end">
                 <div>
                     <button class="btn btn-outline-success btn-sm" [disabled]="addMetricValues.length == 0"

--- a/src/app/shared/shared-facility-forms/kpi-details-form/kpi-details-form.component.ts
+++ b/src/app/shared/shared-facility-forms/kpi-details-form/kpi-details-form.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { faBullseye, faCheck, faCircleQuestion, faContactBook, faPlus, faScaleUnbalancedFlip, faSearchPlus, faTrash, faUser, IconDefinition } from '@fortawesome/free-solid-svg-icons';
+import { faBullseye, faCheck, faCircleQuestion, faContactBook, faLinkSlash, faPlus, faScaleUnbalancedFlip, faSearchPlus, faTrash, faUser, IconDefinition } from '@fortawesome/free-solid-svg-icons';
 import { IdbKeyPerformanceIndicator } from 'src/app/models/keyPerformanceIndicator';
 import { PrimaryKPI, PrimaryKPIs } from '../../constants/keyPerformanceIndicatorOptions';
 import { firstValueFrom, Subscription } from 'rxjs';
@@ -39,6 +39,7 @@ export class KpiDetailsFormComponent {
   faPlus: IconDefinition = faPlus;
   faScaleUnbalancedFlip: IconDefinition = faScaleUnbalancedFlip;
   faCheck: IconDefinition = faCheck;
+  faLinkSlash: IconDefinition = faLinkSlash;
 
   companySub: Subscription;
   company: IdbCompany;
@@ -70,7 +71,6 @@ export class KpiDetailsFormComponent {
     private companyIdbService: CompanyIdbService,
     private contactIdbService: ContactIdbService,
     private keyPerformanceMetricImpactIdbService: KeyPerformanceMetricImpactsIdbService,
-    private sharedDataService: SharedDataService,
     private localeService: LocaleService,
     private dbChangesService: DbChangesService
   ) {
@@ -210,12 +210,12 @@ export class KpiDetailsFormComponent {
     this.usedPerformanceMetrics = new Array();
     if (!this.keyPerformanceIndicator.isCustom) {
       let allPerformanceMetrics: Array<KeyPerformanceMetric> = this.keyPerformanceIndicatorIdbService.getFacilityKeyPerformanceMetrics(this.keyPerformanceIndicator.facilityId);
-      let kpmValues: Array<KeyPerformanceMetricValue> = allPerformanceMetrics.map(metric => {
+      let usedKpmValues: Array<KeyPerformanceMetricValue> = allPerformanceMetrics.map(metric => {
         return metric.value
       });
       let tmpKeyPerformanceMetricOptions: Array<KeyPerformanceMetric> = getPerformanceMetrics(this.keyPerformanceIndicator.optionValue, this.keyPerformanceIndicator.guid)
       tmpKeyPerformanceMetricOptions.forEach(option => {
-        if (kpmValues.includes(option.value) == false) {
+        if (usedKpmValues.includes(option.value) == false) {
           this.keyPerformanceMetricOptions.push(option);
         } else {
           this.usedPerformanceMetrics.push(option);

--- a/src/app/shared/shared-facility-forms/kpi-details-form/kpi-details-form.component.ts
+++ b/src/app/shared/shared-facility-forms/kpi-details-form/kpi-details-form.component.ts
@@ -1,11 +1,11 @@
 import { Component } from '@angular/core';
-import { faBullseye, faCircleQuestion, faContactBook, faPlus, faScaleUnbalancedFlip, faSearchPlus, faTrash, faUser, IconDefinition } from '@fortawesome/free-solid-svg-icons';
+import { faBullseye, faCheck, faCircleQuestion, faContactBook, faPlus, faScaleUnbalancedFlip, faSearchPlus, faTrash, faUser, IconDefinition } from '@fortawesome/free-solid-svg-icons';
 import { IdbKeyPerformanceIndicator } from 'src/app/models/keyPerformanceIndicator';
 import { PrimaryKPI, PrimaryKPIs } from '../../constants/keyPerformanceIndicatorOptions';
 import { firstValueFrom, Subscription } from 'rxjs';
 import { IdbCompany } from 'src/app/models/company';
 import { IdbContact } from 'src/app/models/contact';
-import { getCustomKPM, KeyPerformanceMetric } from '../../constants/keyPerformanceMetrics';
+import { getCustomKPM, getPerformanceMetrics, KeyPerformanceMetric, KeyPerformanceMetricValue } from '../../constants/keyPerformanceMetrics';
 import { IdbKeyPerformanceMetricImpact } from 'src/app/models/keyPerformanceMetricImpact';
 import { ActivatedRoute } from '@angular/router';
 import { KeyPerformanceIndicatorsIdbService } from 'src/app/indexed-db/key-performance-indicators-idb.service';
@@ -17,10 +17,10 @@ import { LocaleService } from '../../shared-services/locale.service';
 import { DbChangesService } from 'src/app/indexed-db/db-changes.service';
 
 @Component({
-    selector: 'app-kpi-details-form',
-    templateUrl: './kpi-details-form.component.html',
-    styleUrl: './kpi-details-form.component.css',
-    standalone: false
+  selector: 'app-kpi-details-form',
+  templateUrl: './kpi-details-form.component.html',
+  styleUrl: './kpi-details-form.component.css',
+  standalone: false
 })
 export class KpiDetailsFormComponent {
   // @Input({ required: true })
@@ -38,6 +38,7 @@ export class KpiDetailsFormComponent {
   faBullseye: IconDefinition = faBullseye;
   faPlus: IconDefinition = faPlus;
   faScaleUnbalancedFlip: IconDefinition = faScaleUnbalancedFlip;
+  faCheck: IconDefinition = faCheck;
 
   companySub: Subscription;
   company: IdbCompany;
@@ -60,6 +61,9 @@ export class KpiDetailsFormComponent {
   currencyCode: string;
   currencySub: Subscription;
 
+  addMetricValues: Array<KeyPerformanceMetricValue> = [];
+  keyPerformanceMetricOptions: Array<KeyPerformanceMetric> = [];
+  usedPerformanceMetrics: Array<KeyPerformanceMetric> = [];
   constructor(
     private keyPerformanceIndicatorIdbService: KeyPerformanceIndicatorsIdbService,
     private activatedRoute: ActivatedRoute,
@@ -88,6 +92,7 @@ export class KpiDetailsFormComponent {
       let kpiGuid: string = params['id'];
       this.keyPerformanceIndicator = this.keyPerformanceIndicatorIdbService.getByGuid(kpiGuid);
       this.showAddMetricDropdown = false;
+      this.setMetricOptions();
     });
 
     this.currencySub = this.localeService.currencyCode.subscribe(code => {
@@ -182,11 +187,48 @@ export class KpiDetailsFormComponent {
     this.displayAddMetricModal = false;
   }
 
-  addMetrics(metrics: Array<KeyPerformanceMetric>) {
+  async addMetrics(metrics: Array<KeyPerformanceMetric>) {
     metrics.forEach(metric => {
       this.keyPerformanceIndicator.performanceMetrics.unshift(metric);
     })
-    this.saveChanges();
+    await this.saveChanges();
+  }
+
+
+  toggleMetric(keyPerformanceMetric: KeyPerformanceMetric) {
+    if (this.addMetricValues.includes(keyPerformanceMetric.value)) {
+      this.addMetricValues = this.addMetricValues.filter(value => {
+        return value != keyPerformanceMetric.value
+      });
+    } else {
+      this.addMetricValues.push(keyPerformanceMetric.value);
+    }
+  }
+
+  setMetricOptions() {
+    this.keyPerformanceMetricOptions = new Array();
+    this.usedPerformanceMetrics = new Array();
+    if (!this.keyPerformanceIndicator.isCustom) {
+      let allPerformanceMetrics: Array<KeyPerformanceMetric> = this.keyPerformanceIndicatorIdbService.getFacilityKeyPerformanceMetrics(this.keyPerformanceIndicator.facilityId);
+      let kpmValues: Array<KeyPerformanceMetricValue> = allPerformanceMetrics.map(metric => {
+        return metric.value
+      });
+      let tmpKeyPerformanceMetricOptions: Array<KeyPerformanceMetric> = getPerformanceMetrics(this.keyPerformanceIndicator.optionValue, this.keyPerformanceIndicator.guid)
+      tmpKeyPerformanceMetricOptions.forEach(option => {
+        if (kpmValues.includes(option.value) == false) {
+          this.keyPerformanceMetricOptions.push(option);
+        } else {
+          this.usedPerformanceMetrics.push(option);
+        }
+      });
+    }
+  }
+
+  async addInitialMetrics() {
+    let metricsToAdd: Array<KeyPerformanceMetric> = this.keyPerformanceMetricOptions.filter(option => {
+      return this.addMetricValues.includes(option.value)
+    });
+    await this.addMetrics(metricsToAdd);
   }
 
 }

--- a/src/app/shared/shared-facility-forms/kpi-details-form/kpm-database-modal/kpm-database-modal.component.css
+++ b/src/app/shared/shared-facility-forms/kpi-details-form/kpm-database-modal/kpm-database-modal.component.css
@@ -1,3 +1,10 @@
 .popup-header{
     font-weight: normal;
 }
+.darkgrey{
+    color: darkgrey;
+}
+
+.clickable:hover{
+    cursor: pointer;
+}

--- a/src/app/shared/shared-facility-forms/kpi-details-form/kpm-database-modal/kpm-database-modal.component.html
+++ b/src/app/shared/shared-facility-forms/kpi-details-form/kpm-database-modal/kpm-database-modal.component.html
@@ -25,8 +25,20 @@
                             <span [innerHTML]="performanceMetric.htmlLabel"></span>
                         </td>
                     </tr>
+                    <tr *ngFor="let performanceMetric of usedPerformanceMetrics">
+                        <td class="darkgrey text-center">
+                            <fa-icon [icon]="faLinkSlash"></fa-icon>
+                        </td>
+                        <td class="darkgrey">
+                            <span [innerHTML]="performanceMetric.htmlLabel"></span>
+                        </td>
+                    </tr>
                 </tbody>
             </table>
+            <p *ngIf="usedPerformanceMetrics.length > 0" class="fw-light small mb-0">
+                <fa-icon [icon]="faLinkSlash"></fa-icon> Indicates metric is in use by another KPI and cannot be
+                duplicated here.
+            </p>
         </ng-template>
         <ng-template #noOptionsBlock>
             <div class="alert alert-info">

--- a/src/app/shared/shared-facility-forms/kpi-details-form/kpm-database-modal/kpm-database-modal.component.spec.ts
+++ b/src/app/shared/shared-facility-forms/kpi-details-form/kpm-database-modal/kpm-database-modal.component.spec.ts
@@ -4,6 +4,7 @@ import { KpmDatabaseModalComponent } from './kpm-database-modal.component';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { getNewKeyPerformanceIndicator } from 'src/app/models/keyPerformanceIndicator';
 import { KeyPerformanceIndicatorOption } from 'src/app/shared/constants/keyPerformanceIndicatorOptions';
+import { stubServiceProviders } from 'src/app/spec-helpers/spec-test-service-stub';
 
 describe('KpmDatabaseModalComponent', () => {
   let component: KpmDatabaseModalComponent;
@@ -12,7 +13,8 @@ describe('KpmDatabaseModalComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [FontAwesomeModule],
-      declarations: [KpmDatabaseModalComponent]
+      declarations: [KpmDatabaseModalComponent],
+      providers: stubServiceProviders
     })
       .compileComponents();
 

--- a/src/app/shared/shared-facility-forms/kpi-details-form/kpm-database-modal/kpm-database-modal.component.ts
+++ b/src/app/shared/shared-facility-forms/kpi-details-form/kpm-database-modal/kpm-database-modal.component.ts
@@ -1,13 +1,14 @@
 import { ChangeDetectorRef, Component, EventEmitter, Input, Output } from '@angular/core';
-import { faCheck, faPlus, IconDefinition } from '@fortawesome/free-solid-svg-icons';
+import { faCheck, faLinkSlash, faPlus, IconDefinition } from '@fortawesome/free-solid-svg-icons';
+import { KeyPerformanceIndicatorsIdbService } from 'src/app/indexed-db/key-performance-indicators-idb.service';
 import { IdbKeyPerformanceIndicator } from 'src/app/models/keyPerformanceIndicator';
 import { getPerformanceMetrics, KeyPerformanceMetric, KeyPerformanceMetricValue } from 'src/app/shared/constants/keyPerformanceMetrics';
 
 @Component({
-    selector: 'app-kpm-database-modal',
-    templateUrl: './kpm-database-modal.component.html',
-    styleUrl: './kpm-database-modal.component.css',
-    standalone: false
+  selector: 'app-kpm-database-modal',
+  templateUrl: './kpm-database-modal.component.html',
+  styleUrl: './kpm-database-modal.component.css',
+  standalone: false
 })
 export class KpmDatabaseModalComponent {
   @Output('emitClose')
@@ -19,11 +20,15 @@ export class KpmDatabaseModalComponent {
 
   faPlus: IconDefinition = faPlus;
   faCheck: IconDefinition = faCheck;
+  faLinkSlash: IconDefinition = faLinkSlash;
   displayModal: boolean = false;
 
   keyPerformanceMetricOptions: Array<KeyPerformanceMetric>;
   addMetricValues: Array<KeyPerformanceMetricValue> = [];
-  constructor(private cd: ChangeDetectorRef) {
+  usedPerformanceMetrics: Array<KeyPerformanceMetric> = [];
+  constructor(private cd: ChangeDetectorRef,
+    private keyPerformanceIndicatorIdbService: KeyPerformanceIndicatorsIdbService
+  ) {
 
   }
 
@@ -34,10 +39,19 @@ export class KpmDatabaseModalComponent {
 
     this.keyPerformanceMetricOptions = new Array();
 
+    let allPerformanceMetrics: Array<KeyPerformanceMetric> = this.keyPerformanceIndicatorIdbService.getFacilityKeyPerformanceMetrics(this.keyPerformanceIndicator.facilityId);
+    let usedKpmValues: Array<KeyPerformanceMetricValue> = allPerformanceMetrics.map(metric => {
+      return metric.value
+    });
+
     let tmpKeyPerformanceMetricOptions: Array<KeyPerformanceMetric> = getPerformanceMetrics(this.keyPerformanceIndicator.optionValue, this.keyPerformanceIndicator.guid)
     tmpKeyPerformanceMetricOptions.forEach(option => {
-      if (currentTrackedMetrics.includes(option.value) == false) {
-        this.keyPerformanceMetricOptions.push(option);
+      if (usedKpmValues.includes(option.value) == false) {
+        if (currentTrackedMetrics.includes(option.value) == false) {
+          this.keyPerformanceMetricOptions.push(option);
+        }
+      } else {
+        this.usedPerformanceMetrics.push(option);
       }
     });
   }


### PR DESCRIPTION
connects #554 
connects #332 

This pull request enhances the KPI details form by improving the user experience for adding performance metrics to a KPI. The main changes include a more informative UI for selecting metrics, new logic for handling available and already-used metrics, and minor code cleanups.

**UI/UX improvements for metric selection:**

* Updated the KPI details form to display a list of preset performance metrics for selection when none are currently connected, including clearer instructions and UI feedback for users. Metrics already in use by other KPIs are now highlighted and cannot be re-added.
