### PR TITLE
Issue 633: collapse potential impacts table in example facilities

### DIFF
--- a/src/app/core-components/welcome/welcome.component.ts
+++ b/src/app/core-components/welcome/welcome.component.ts
@@ -133,6 +133,9 @@ export class WelcomeComponent {
         try {
           let fileData: string = reader.result as string;
           let tmpBackupFile: BackupFile = JSON.parse(fileData);
+          tmpBackupFile.facilities.forEach(facility => {
+            facility.isExample = true;
+          });
           let updatedBackupFile: BackupFile = await this.backupDataService.importUserBackupFile(tmpBackupFile, this.user.guid);
           this.user.kpiFacilityMigrationDoneV2 = false;
           await this.updateDbEntriesService.updateDbEntries(this.user);
@@ -183,6 +186,9 @@ export class WelcomeComponent {
         try {
           let fileData: string = reader.result as string;
           let tmpBackupFile: BackupFile = JSON.parse(fileData);
+          tmpBackupFile.facilities.forEach(facility => {
+            facility.isExample = true;
+          });
           let updatedBackupFile: BackupFile = await this.backupDataService.importUserBackupFile(tmpBackupFile, this.user.guid);
           this.user.kpiFacilityMigrationDoneV2 = false;
           await this.updateDbEntriesService.updateDbEntries(this.user);

--- a/src/app/models/facility.ts
+++ b/src/app/models/facility.ts
@@ -25,7 +25,8 @@ export interface IdbFacility extends IdbEntry {
     outsidePressures: string,
     financialMetricsUsed: string,
     efficiencyIncentives: string,
-    dependentFunding: string
+    dependentFunding: string,
+    isExample?: boolean
 }
 
 export function getNewIdbFacility(userId: string, companyId: string): IdbFacility {

--- a/src/app/shared/shared-facility-forms/kpi-details-form/kpi-details-form.component.ts
+++ b/src/app/shared/shared-facility-forms/kpi-details-form/kpi-details-form.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { faBullseye, faCircleQuestion, faContactBook, faPlus, faScaleUnbalancedFlip, faSearchPlus, faTrash, faUser, IconDefinition } from '@fortawesome/free-solid-svg-icons';
 import { IdbKeyPerformanceIndicator } from 'src/app/models/keyPerformanceIndicator';
 import { PrimaryKPI, PrimaryKPIs } from '../../constants/keyPerformanceIndicatorOptions';
-import { firstValueFrom, Subscription } from 'rxjs';
+import { Subscription } from 'rxjs';
 import { IdbCompany } from 'src/app/models/company';
 import { IdbContact } from 'src/app/models/contact';
 import { getCustomKPM, KeyPerformanceMetric } from '../../constants/keyPerformanceMetrics';
@@ -12,7 +12,6 @@ import { KeyPerformanceIndicatorsIdbService } from 'src/app/indexed-db/key-perfo
 import { CompanyIdbService } from 'src/app/indexed-db/company-idb.service';
 import { ContactIdbService } from 'src/app/indexed-db/contact-idb.service';
 import { KeyPerformanceMetricImpactsIdbService } from 'src/app/indexed-db/key-performance-metric-impacts-idb.service';
-import { SharedDataService } from '../../shared-services/shared-data.service';
 import { LocaleService } from '../../shared-services/locale.service';
 import { DbChangesService } from 'src/app/indexed-db/db-changes.service';
 
@@ -66,7 +65,6 @@ export class KpiDetailsFormComponent {
     private companyIdbService: CompanyIdbService,
     private contactIdbService: ContactIdbService,
     private keyPerformanceMetricImpactIdbService: KeyPerformanceMetricImpactsIdbService,
-    private sharedDataService: SharedDataService,
     private localeService: LocaleService,
     private dbChangesService: DbChangesService
   ) {

--- a/src/app/shared/shared-facility-forms/kpi-details-form/kpm-impacts-table/kpm-impacts-table.component.spec.ts
+++ b/src/app/shared/shared-facility-forms/kpi-details-form/kpm-impacts-table/kpm-impacts-table.component.spec.ts
@@ -1,45 +1,19 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { KpmImpactsTableComponent } from './kpm-impacts-table.component';
-import { KeyPerformanceMetricImpactsIdbService } from 'src/app/indexed-db/key-performance-metric-impacts-idb.service';
-import { IdbKeyPerformanceMetricImpact } from 'src/app/models/keyPerformanceMetricImpact';
-import { BehaviorSubject } from 'rxjs';
-import { AssessmentIdbService } from 'src/app/indexed-db/assessment-idb.service';
-import { NonEnergyBenefitsIdbService } from 'src/app/indexed-db/non-energy-benefits-idb.service';
-import { EnergyOpportunityIdbService } from 'src/app/indexed-db/energy-opportunity-idb.service';
-import { IdbAssessment } from 'src/app/models/assessment';
-import { IdbNonEnergyBenefit } from 'src/app/models/nonEnergyBenefit';
-import { IdbEnergyOpportunity } from 'src/app/models/energyOpportunity';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { HelperPipesModule } from 'src/app/shared/helper-pipes/_helper-pipes.module';
+import { stubServiceProviders } from 'src/app/spec-helpers/spec-test-service-stub';
 
 describe('KpmImpactsTableComponent', () => {
   let component: KpmImpactsTableComponent;
   let fixture: ComponentFixture<KpmImpactsTableComponent>;
 
-  let keyPerformanceMetricImpactsIdbService: Partial<KeyPerformanceMetricImpactsIdbService> = {
-    keyPerformanceMetricImpacts: new BehaviorSubject<Array<IdbKeyPerformanceMetricImpact>>([])
-  };
-  let assessmentIdbService: Partial<AssessmentIdbService> = {
-    assessments: new BehaviorSubject<Array<IdbAssessment>>([])
-  };
-  let nonEnergyBenefitsIdbService: Partial<NonEnergyBenefitsIdbService> = {
-    nonEnergyBenefits: new BehaviorSubject<Array<IdbNonEnergyBenefit>>([])
-  };
-  let energyOpportunityIdbService: Partial<EnergyOpportunityIdbService> = {
-    energyOpportunities: new BehaviorSubject<Array<IdbEnergyOpportunity>>([])
-  };
-
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [FontAwesomeModule, HelperPipesModule],
       declarations: [KpmImpactsTableComponent],
-      providers: [
-        { provide: EnergyOpportunityIdbService, useValue: energyOpportunityIdbService },
-        { provide: AssessmentIdbService, useValue: assessmentIdbService },
-        { provide: NonEnergyBenefitsIdbService, useValue: nonEnergyBenefitsIdbService },
-        { provide: KeyPerformanceMetricImpactsIdbService, useValue: keyPerformanceMetricImpactsIdbService }
-      ]
+      providers: stubServiceProviders
     })
       .compileComponents();
 

--- a/src/app/shared/shared-facility-forms/kpi-details-form/kpm-impacts-table/kpm-impacts-table.component.ts
+++ b/src/app/shared/shared-facility-forms/kpi-details-form/kpm-impacts-table/kpm-impacts-table.component.ts
@@ -3,6 +3,7 @@ import { faChevronDown, faChevronRight, faDollar, faFileLines, faScrewdriverWren
 import { Subscription } from 'rxjs';
 import { AssessmentIdbService } from 'src/app/indexed-db/assessment-idb.service';
 import { EnergyOpportunityIdbService } from 'src/app/indexed-db/energy-opportunity-idb.service';
+import { FacilityIdbService } from 'src/app/indexed-db/facility-idb.service';
 import { KeyPerformanceMetricImpactsIdbService } from 'src/app/indexed-db/key-performance-metric-impacts-idb.service';
 import { NonEnergyBenefitsIdbService } from 'src/app/indexed-db/non-energy-benefits-idb.service';
 import { IdbAssessment } from 'src/app/models/assessment';
@@ -12,10 +13,10 @@ import { IdbNonEnergyBenefit } from 'src/app/models/nonEnergyBenefit';
 import { LocaleService } from 'src/app/shared/shared-services/locale.service';
 
 @Component({
-    selector: 'app-kpm-impacts-table',
-    templateUrl: './kpm-impacts-table.component.html',
-    styleUrl: './kpm-impacts-table.component.css',
-    standalone: false
+  selector: 'app-kpm-impacts-table',
+  templateUrl: './kpm-impacts-table.component.html',
+  styleUrl: './kpm-impacts-table.component.css',
+  standalone: false
 })
 export class KpmImpactsTableComponent {
   @Input({ required: true })
@@ -45,12 +46,14 @@ export class KpmImpactsTableComponent {
   currencyCode: string;
   currencySub: Subscription;
 
+  facilitySub: Subscription;
   constructor(
     private keyPerformanceMetricImpactIdbService: KeyPerformanceMetricImpactsIdbService,
     private assessmentIdbService: AssessmentIdbService,
     private energyOpportunityIdbService: EnergyOpportunityIdbService,
     private nonEnergyBenefitsIdbService: NonEnergyBenefitsIdbService,
     private localeService: LocaleService,
+    private facilityIdbService: FacilityIdbService
   ) {
 
   }
@@ -75,6 +78,12 @@ export class KpmImpactsTableComponent {
     this.currencySub = this.localeService.currencyCode.subscribe(code => {
       this.currencyCode = code;
     });
+
+    this.facilitySub = this.facilityIdbService.selectedFacility.subscribe(facility => {
+      if (facility && facility.isExample) {
+        this.displayTable = false;
+      }
+    });
   }
 
   ngOnDestroy() {
@@ -85,7 +94,7 @@ export class KpmImpactsTableComponent {
     this.currencySub.unsubscribe();
   }
 
-  toggleDisplayTable(){
+  toggleDisplayTable() {
     this.displayTable = !this.displayTable;
   }
 }


### PR DESCRIPTION
connects #633 
This pull request introduces support for marking facilities as example data and updates the UI to reflect this status. It also includes some cleanup of unused imports and dependency injections. The most significant changes are grouped below.

**Support for Example Facilities:**

* Added an optional `isExample` property to the `IdbFacility` interface, allowing facilities to be flagged as example data (`src/app/models/facility.ts`).
* When importing a example file in `WelcomeComponent`, all facilities are now marked as example by setting `isExample = true` (`src/app/core-components/welcome/welcome.component.ts`). [[1]](diffhunk://#diff-9d1849a4709b0d398f9986c09d946028552a650fb4819c705c8bd8e4e969dcc4R136-R138) [[2]](diffhunk://#diff-9d1849a4709b0d398f9986c09d946028552a650fb4819c705c8bd8e4e969dcc4R189-R191)

**UI Behavior for Example Facilities:**

* In `KpmImpactsTableComponent`, added logic to hide the KPI impacts table if the selected facility is marked as an example (`src/app/shared/shared-facility-forms/kpi-details-form/kpm-impacts-table/kpm-impacts-table.component.ts`). [[1]](diffhunk://#diff-494fce0d791ba6f61900ca1314abb39bd5a8a7a1766f5bf1af40d3e0a49245c7R6) [[2]](diffhunk://#diff-494fce0d791ba6f61900ca1314abb39bd5a8a7a1766f5bf1af40d3e0a49245c7R49-R56) [[3]](diffhunk://#diff-494fce0d791ba6f61900ca1314abb39bd5a8a7a1766f5bf1af40d3e0a49245c7R81-R86)

**Code Cleanup:**

* Removed unused imports and dependency injections from `KpiDetailsFormComponent` to simplify the codebase (`src/app/shared/shared-facility-forms/kpi-details-form/kpi-details-form.component.ts`). [[1]](diffhunk://#diff-bbf4b611bfbe536d41203502bdb02da90833b85564d7348b3916f622e637fbceL5-R5) [[2]](diffhunk://#diff-bbf4b611bfbe536d41203502bdb02da90833b85564d7348b3916f622e637fbceL15) [[3]](diffhunk://#diff-bbf4b611bfbe536d41203502bdb02da90833b85564d7348b3916f622e637fbceL69)