### PR TITLE
Issue 332: use btn-success for add metric

### DIFF
--- a/src/app/shared/shared-facility-forms/kpi-details-form/kpi-details-form.component.html
+++ b/src/app/shared/shared-facility-forms/kpi-details-form/kpi-details-form.component.html
@@ -216,7 +216,7 @@
             </p>
             <div class="d-flex w-100 justify-content-end">
                 <div>
-                    <button class="btn btn-outline-success btn-sm" [disabled]="addMetricValues.length == 0"
+                    <button class="btn btn-success btn-sm" [disabled]="addMetricValues.length == 0"
                         (click)="addInitialMetrics()">Add Metrics</button>
                 </div>
             </div>

--- a/src/app/shared/shared-facility-forms/kpi-details-form/kpi-details-form.component.ts
+++ b/src/app/shared/shared-facility-forms/kpi-details-form/kpi-details-form.component.ts
@@ -215,9 +215,9 @@ export class KpiDetailsFormComponent {
       let tmpKeyPerformanceMetricOptions: Array<KeyPerformanceMetric> = getPerformanceMetrics(this.keyPerformanceIndicator.optionValue, this.keyPerformanceIndicator.guid)
       tmpKeyPerformanceMetricOptions.forEach(option => {
         if (usedKpmValues.includes(option.value) == false) {
-          this.keyPerformanceMetricOptions.push(option);
+          this.keyPerformanceMetricOptions.push({...option});
         } else {
-          this.usedPerformanceMetrics.push(option);
+          this.usedPerformanceMetrics.push({...option});
         }
       });
     }

--- a/src/app/shared/shared-facility-forms/kpi-details-form/kpm-database-modal/kpm-database-modal.component.ts
+++ b/src/app/shared/shared-facility-forms/kpi-details-form/kpm-database-modal/kpm-database-modal.component.ts
@@ -48,10 +48,10 @@ export class KpmDatabaseModalComponent {
     tmpKeyPerformanceMetricOptions.forEach(option => {
       if (usedKpmValues.includes(option.value) == false) {
         if (currentTrackedMetrics.includes(option.value) == false) {
-          this.keyPerformanceMetricOptions.push(option);
+          this.keyPerformanceMetricOptions.push({...option});
         }
       } else {
-        this.usedPerformanceMetrics.push(option);
+        this.usedPerformanceMetrics.push({...option});
       }
     });
   }


### PR DESCRIPTION
connects #332 

use copy of metric to prevent editing global data.