### PR TITLE
Issue 217 - added option to add custom KPM on KPM list page

### DIFF
--- a/src/app/shared/kpm-details-form/kpm-details-form.component.html
+++ b/src/app/shared/kpm-details-form/kpm-details-form.component.html
@@ -1,4 +1,4 @@
-<div class="row">
+<div class="row g-0">
     <label class="col-sm-6 col-form-label" for="{{'isQuantitative_'+keyPerformanceMetric.value}}">
         Metric Type
     </label>
@@ -12,7 +12,7 @@
     </div>
 </div>
 <ng-template [ngIf]="keyPerformanceMetric.isQuantitative">
-    <div class="row">
+    <div class="row g-0">
         <!-- <label class="col-sm-6 col-form-label"
             for="{{'goalToIncrease_'+keyPerformanceMetric.value}}">
             Desired Impact
@@ -30,7 +30,7 @@
             </select>
         </div>
     </div>
-    <div class="row">
+    <div class="row g-0">
         <!-- <label class="col-sm-6 col-form-label" for="{{'calculationMethod_'+keyPerformanceMetric.value}}">
             Calculation Method
         </label> -->
@@ -53,7 +53,7 @@
 
     <!--COST PER UNIT-->
     <ng-template [ngIf]="keyPerformanceMetric.calculationMethod == 'costPerUnit'">
-        <div class="row">
+        <div class="row g-0">
             <label class="col-sm-6 col-form-label" for="{{'totalUnit_'+keyPerformanceMetric.value}}">
                 Unit
             </label>
@@ -81,7 +81,7 @@
                 </select>
             </div>
         </div> -->
-        <div class="row">
+        <div class="row g-0">
             <label class="col-sm-6 col-form-label" for="{{'baselineValue_'+keyPerformanceMetric.value}}">
                 Baseline Amount
             </label>
@@ -103,7 +103,7 @@
             </div>
         </div>
 
-        <div class="row">
+        <div class="row g-0">
             <label class="col-sm-6 col-form-label" for="{{'costPerValue_'+keyPerformanceMetric.value}}">
                 Per Unit
             </label>
@@ -122,7 +122,7 @@
             </div>
         </div>
 
-        <div class="row">
+        <div class="row g-0">
             <label class="col-sm-6 col-form-label" for="{{'baselineCost_'+keyPerformanceMetric.value}}">
                 {{ keyPerformanceMetric.goalToIncrease ? 'Baseline Revenue' : 'Baseline Cost' }}
             </label>
@@ -138,7 +138,7 @@
     </ng-template>
     <!--DIRECT COST or PERCENT-->
     <ng-template [ngIf]="keyPerformanceMetric.calculationMethod != 'costPerUnit'">
-        <div class="row">
+        <div class="row g-0">
             <label class="col-sm-6 col-form-label" for="{{'baselineCost_'+keyPerformanceMetric.value}}">
                 {{ keyPerformanceMetric.goalToIncrease ? 'Baseline Revenue' : 'Baseline Cost' }}
             </label>

--- a/src/app/shared/shared-assessment-forms/neb-forms-accordion/neb-setup-form/performance-metrics-modal/performance-metrics-modal.component.css
+++ b/src/app/shared/shared-assessment-forms/neb-forms-accordion/neb-setup-form/performance-metrics-modal/performance-metrics-modal.component.css
@@ -2,3 +2,15 @@
     max-height: 200px;
     overflow-y: auto;
 }
+
+.kpi-select {
+    line-height: 1.5;
+}
+
+.alert.alert-success {
+    margin-bottom: 0;
+    align-self: center;
+    padding-right: 7rem;
+    padding-left: 7rem;
+    border-radius: 1rem;
+}

--- a/src/app/shared/shared-assessment-forms/neb-forms-accordion/neb-setup-form/performance-metrics-modal/performance-metrics-modal.component.html
+++ b/src/app/shared/shared-assessment-forms/neb-forms-accordion/neb-setup-form/performance-metrics-modal/performance-metrics-modal.component.html
@@ -11,101 +11,105 @@
         <button type="button" class="btn-close float-end" aria-label="Close" (click)="closeAddMetricModal()"></button>
     </div>
     <div class="popup-body" *ngIf="displayMetricsModal">
-        <ng-template [ngIf]="!performanceMetricToAdd" [ngIfElse]="selectedMetricBlock">
-            <div class="row justify-content-between mb-2">
-                <!-- <div class="col">
+        <ng-template [ngIf]="!isCustomKPM" [ngIfElse]="customKpmBlock">
+            <ng-template [ngIf]="!performanceMetricToAdd" [ngIfElse]="selectedMetricBlock">
+                <div class="row justify-content-between mb-2">
+                    <!-- <div class="col">
                     <div class="form-check form-switch">
                         <input class="form-check-input" type="checkbox" role="switch" id="displayAllMetrics"
                             [(ngModel)]="displayAllMetrics" (change)="setMetricOptions()">
                         <label class="form-check-label" for="displayAllMetrics">Display untracked KPMs</label>
                     </div>
                 </div> -->
-                <div class="col">
-                    <div class="form-check form-switch">
-                        <input class="form-check-input" type="checkbox" role="switch" id="filterAssociatedMetrics"
-                            [(ngModel)]="filterAssociatedMetrics" (change)="setMetricOptions()">
-                        <label class="form-check-label" for="filterAssociatedMetrics">Filter associated metrics</label>
+                    <div class="col">
+                        <div class="form-check form-switch">
+                            <input class="form-check-input" type="checkbox" role="switch" id="filterAssociatedMetrics"
+                                [(ngModel)]="filterAssociatedMetrics" (change)="setMetricOptions()">
+                            <label class="form-check-label" for="filterAssociatedMetrics">Filter associated
+                                metrics</label>
+                        </div>
+                        <p class="small mb-0">
+                            <fa-icon [icon]="faAsterisk"></fa-icon> Denotes metric typically associated with
+                            {{nonEnergyBenefit.name}}.
+                        </p>
                     </div>
-                    <p class="small mb-0">
-                        <fa-icon [icon]="faAsterisk"></fa-icon> Denotes metric typically associated with
-                        {{nonEnergyBenefit.name}}.
-                    </p>
-                </div>
-                <div class="col-3">
-                    <div class="input-group" role="search">
-                        <span class="input-group-text">
-                            <fa-icon [icon]="faMagnifyingGlass"></fa-icon>
-                        </span>
-                        <input class="form-control" type="search" placeholder="Search" aria-label="Search"
-                        name="kpmSearchStr" [(ngModel)]="kpmSearchStr" (input)="filterKpmKeywordList()">
+                    <div class="col-3">
+                        <div class="input-group" role="search">
+                            <span class="input-group-text">
+                                <fa-icon [icon]="faMagnifyingGlass"></fa-icon>
+                            </span>
+                            <input class="form-control" type="search" placeholder="Search" aria-label="Search"
+                                name="kpmSearchStr" [(ngModel)]="kpmSearchStr" (input)="filterKpmKeywordList()">
+                        </div>
+                        <ul *ngIf="kpmSearchStr && filteredKpmKeywordList.length > 0"
+                            class="dropdown-menu show scrollable">
+                            <li *ngFor="let keyword of filteredKpmKeywordList" class="dropdown-item"
+                                (click)="keyword != '...' && selectKpmKeyword(keyword)"
+                                [innerHTML]="keyword | keywordHighlight: kpmSearchStr">
+                            </li>
+                        </ul>
                     </div>
-                    <ul *ngIf="kpmSearchStr && filteredKpmKeywordList.length > 0" class="dropdown-menu show scrollable">
-                        <li *ngFor="let keyword of filteredKpmKeywordList"
-                        class="dropdown-item"
-                        (click)="keyword != '...' && selectKpmKeyword(keyword)"
-                        [innerHTML]="keyword | keywordHighlight: kpmSearchStr">
-                        </li>
-                    </ul>
                 </div>
-            </div>
-            <ng-template
-                [ngIf]="(performanceMetricOptions | metricOptionsModalList: kpmSearchStr: orderByDir).length > 0"
-                [ngIfElse]="noOptionsBlock">
-                <table class="table table-bordered table-hover table-sm">
-                    <thead>
-                        <tr>
-                            <th>
+                <ng-template
+                    [ngIf]="(performanceMetricOptions | metricOptionsModalList: kpmSearchStr: orderByDir).length > 0"
+                    [ngIfElse]="noOptionsBlock">
+                    <table class="table table-bordered table-hover table-sm">
+                        <thead>
+                            <tr>
+                                <th>
 
-                            </th>
-                            <th (click)="toggleOrderBy()">
-                                <fa-icon [icon]="faChevronDown" *ngIf="orderByDir == 'asc'"></fa-icon>
-                                <fa-icon [icon]="faChevronUp" *ngIf="orderByDir == 'desc'"></fa-icon>
-                                Key Performance Metric
-                            </th>
-                            <th>
-                                KPI
-                            </th>
-                            <th>
-                                Category
-                            </th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr class="clickable" (click)="addMetric(performanceMetric)"
-                            *ngFor="let performanceMetric of performanceMetricOptions | metricOptionsModalList: kpmSearchStr: orderByDir">
-                            <td class="add-td text-center">
-                                <a class="click-link">
-                                    <fa-icon [icon]="faPlus"></fa-icon>
-                                </a>
-                            </td>
-                            <td>
-                                <ng-template [ngIf]="nonEnergyBenefit | associatedMetricIndicator: performanceMetric">
-                                    <fa-icon class="pe-2" [icon]="faAsterisk"></fa-icon>
-                                </ng-template>
-                                <span [innerHTML]="performanceMetric.htmlLabel"></span>
-                            </td>
-                            <td>
-                                <ng-template [ngIf]="performanceMetric.kpiGuid" [ngIfElse]="nonExistingBlock">
-                                    <span
-                                        [innerHTML]="performanceMetric.kpiGuid | kpiLabel:keyPerformanceIndicators"></span>
-                                </ng-template>
-                                <ng-template #nonExistingBlock>
-                                    <span
-                                        [innerHTML]="performanceMetric.kpiValue | kpiValueDisplay:keyPerformanceIndicators"></span>
-                                </ng-template>
-                            </td>
-                            <td>
-                                <app-primary-kpi-badge [kpiValue]="performanceMetric.kpiValue"
-                                    [facilityId]="nonEnergyBenefit.facilityId"></app-primary-kpi-badge>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </ng-template>
-            <ng-template #noOptionsBlock>
-                <div class="alert alert-warning">
-                    No performance metrics found matching the search criteria.
-                </div>
+                                </th>
+                                <th (click)="toggleOrderBy()">
+                                    <fa-icon [icon]="faChevronDown" *ngIf="orderByDir == 'asc'"></fa-icon>
+                                    <fa-icon [icon]="faChevronUp" *ngIf="orderByDir == 'desc'"></fa-icon>
+                                    Key Performance Metric
+                                </th>
+                                <th>
+                                    KPI
+                                </th>
+                                <th>
+                                    Category
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr class="clickable" (click)="addMetric(performanceMetric)"
+                                *ngFor="let performanceMetric of performanceMetricOptions | metricOptionsModalList: kpmSearchStr: orderByDir">
+                                <td class="add-td text-center">
+                                    <a class="click-link">
+                                        <fa-icon [icon]="faPlus"></fa-icon>
+                                    </a>
+                                </td>
+                                <td>
+                                    <ng-template
+                                        [ngIf]="nonEnergyBenefit | associatedMetricIndicator: performanceMetric">
+                                        <fa-icon class="pe-2" [icon]="faAsterisk"></fa-icon>
+                                    </ng-template>
+                                    <span [innerHTML]="performanceMetric.htmlLabel"></span>
+                                </td>
+                                <td>
+                                    <ng-template [ngIf]="performanceMetric.kpiGuid" [ngIfElse]="nonExistingBlock">
+                                        <span
+                                            [innerHTML]="performanceMetric.kpiGuid | kpiLabel:keyPerformanceIndicators"></span>
+                                    </ng-template>
+                                    <ng-template #nonExistingBlock>
+                                        <span
+                                            [innerHTML]="performanceMetric.kpiValue | kpiValueDisplay:keyPerformanceIndicators"></span>
+                                    </ng-template>
+                                </td>
+                                <td>
+                                    <app-primary-kpi-badge [kpiValue]="performanceMetric.kpiValue"
+                                        [facilityId]="nonEnergyBenefit.facilityId"></app-primary-kpi-badge>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </ng-template>
+                <ng-template #noOptionsBlock>
+                    <div class="alert alert-warning">
+                        No performance metrics found matching the search criteria.
+                    </div>
+                </ng-template>
             </ng-template>
         </ng-template>
         <ng-template #selectedMetricBlock>
@@ -113,6 +117,60 @@
                 Would you like to add this performance metric: <span class="bold"
                     [innerHTML]="performanceMetricToAdd?.htmlLabel"></span>?
             </div>
+        </ng-template>
+        <ng-template #customKpmBlock>
+             <a class="click-link mt-3 ms-3" (click)="goToMetricsList()">
+                <fa-icon [icon]="faChevronLeft" class="me-1"></fa-icon> Go to Metrics List
+            </a>
+            <div class="row justify-content-center mt-4">
+                <label class="col-1 col-form-label">Select KPI</label>
+                <div class="col-2">
+                    <select name="selectedKpi" class="form-select kpi-select" id="selectedKpi" [(ngModel)]="selectedKpi"
+                        (ngModelChange)="onSelectedKpiChange($event)">
+                        <option *ngFor="let kpi of facilityKpis" [ngValue]="kpi">
+                            {{kpi.htmlLabel}}
+                        </option>
+                    </select>
+                </div>
+            </div>
+<button type="button" class="btn btn-secondary" data-bs-toggle="tooltip" title="Test tooltip!">
+  Hover me
+</button>
+            <div class="mt-5" *ngIf="selectedKpi">
+                <div class="row">
+                    <label class="col-sm-6 col-form-label" for="{{'kpmName_'+customKpmToAdd?.guid}}">
+                        Performance Metric Name
+                    </label>
+                    <div class="col-6">
+                        <div class="input-group">
+                            <div class="input-group-text">
+                                <fa-icon [icon]="faScaleUnbalancedFlip"></fa-icon>
+                            </div>
+                            <input name="{{'kpmName_'+customKpmToAdd?.guid}}" type="text" class="form-control"
+                                [(ngModel)]="customKpmToAdd.label" id="{{'kpmName_'+customKpmToAdd?.guid}}"
+                                (input)="saveChanges()">
+                        </div>
+                    </div>
+                </div>
+
+                <app-kpm-details-form [keyPerformanceMetric]="customKpmToAdd" (emitSave)="saveChanges()"
+                    (emitCalculate)="calculateCost(customKpmToAdd)" [context]="'preVisit'"
+                    [currencyCode]="currencyCode"></app-kpm-details-form>
+
+                <div class="d-flex justify-content-center mt-5">
+                    <button *ngIf="!showSuccessMsg" class="me-2 btn btn-primary btn-sm px-5 py-2" (click)="addSelectedKpi()">
+                        <fa-icon [icon]="faPlus" class="me-1"></fa-icon>
+                        Add Performance Metric
+                    </button>
+
+                    <div *ngIf="showSuccessMsg" class="alert alert-success">
+                        The performance metric has been added to the selected KPI. 
+                    </div>
+                </div>
+
+            </div>
+
+
         </ng-template>
     </div>
     <div class="popup-footer">
@@ -122,6 +180,10 @@
             </div>
             <div class="d-flex justify-content-end">
                 <button class="btn btn-secondary btn-sm me-2" (click)="closeAddMetricModal()">Cancel</button>
+                <button *ngIf="!isCustomKPM" class="btn btn-outline-success btn-sm me-2" (click)="addCustomKPM()">
+                    <fa-icon [icon]="faPlus" class="me-1"></fa-icon>
+                    Add Custom KPM
+                </button>
                 <button class="btn btn-success btn-sm" (click)="confirmAddMetric()"
                     [disabled]="!performanceMetricToAdd"><fa-icon [icon]="faPlus" class="me-1"></fa-icon>Add
                     Metric</button>

--- a/src/app/shared/shared-assessment-forms/neb-forms-accordion/neb-setup-form/performance-metrics-modal/performance-metrics-modal.component.html
+++ b/src/app/shared/shared-assessment-forms/neb-forms-accordion/neb-setup-form/performance-metrics-modal/performance-metrics-modal.component.html
@@ -13,7 +13,7 @@
     <div class="popup-body" *ngIf="displayMetricsModal">
         <ng-template [ngIf]="!isCustomKPM" [ngIfElse]="customKpmBlock">
             <ng-template [ngIf]="!performanceMetricToAdd" [ngIfElse]="selectedMetricBlock">
-                <div class="row justify-content-between mb-2">
+                <div class="row g-0 justify-content-between mb-2">
                     <!-- <div class="col">
                     <div class="form-check form-switch">
                         <input class="form-check-input" type="checkbox" role="switch" id="displayAllMetrics"
@@ -119,7 +119,7 @@
             </div>
         </ng-template>
         <ng-template #customKpmBlock>
-            <div class="row justify-content-center mt-4">
+            <div class="row g-0 justify-content-center mt-4">
                 <label class="col-1 col-form-label">Select KPI</label>
                 <div class="col-2">
                     <select name="selectedKpi" class="form-select kpi-select" id="selectedKpi" [(ngModel)]="selectedKpi"
@@ -132,7 +132,7 @@
             </div>
 
             <div class="mt-5" *ngIf="selectedKpi">
-                <div class="row">
+                <div class="row g-0">
                     <label class="col-sm-6 col-form-label" for="{{'kpmName_'+customKpmToAdd?.guid}}">
                         Performance Metric Name
                     </label>

--- a/src/app/shared/shared-assessment-forms/neb-forms-accordion/neb-setup-form/performance-metrics-modal/performance-metrics-modal.component.html
+++ b/src/app/shared/shared-assessment-forms/neb-forms-accordion/neb-setup-form/performance-metrics-modal/performance-metrics-modal.component.html
@@ -119,9 +119,6 @@
             </div>
         </ng-template>
         <ng-template #customKpmBlock>
-             <a class="click-link mt-3 ms-3" (click)="goToMetricsList()">
-                <fa-icon [icon]="faChevronLeft" class="me-1"></fa-icon> Go to Metrics List
-            </a>
             <div class="row justify-content-center mt-4">
                 <label class="col-1 col-form-label">Select KPI</label>
                 <div class="col-2">
@@ -133,9 +130,7 @@
                     </select>
                 </div>
             </div>
-<button type="button" class="btn btn-secondary" data-bs-toggle="tooltip" title="Test tooltip!">
-  Hover me
-</button>
+
             <div class="mt-5" *ngIf="selectedKpi">
                 <div class="row">
                     <label class="col-sm-6 col-form-label" for="{{'kpmName_'+customKpmToAdd?.guid}}">
@@ -156,18 +151,6 @@
                 <app-kpm-details-form [keyPerformanceMetric]="customKpmToAdd" (emitSave)="saveChanges()"
                     (emitCalculate)="calculateCost(customKpmToAdd)" [context]="'preVisit'"
                     [currencyCode]="currencyCode"></app-kpm-details-form>
-
-                <div class="d-flex justify-content-center mt-5">
-                    <button *ngIf="!showSuccessMsg" class="me-2 btn btn-primary btn-sm px-5 py-2" (click)="addSelectedKpi()">
-                        <fa-icon [icon]="faPlus" class="me-1"></fa-icon>
-                        Add Performance Metric
-                    </button>
-
-                    <div *ngIf="showSuccessMsg" class="alert alert-success">
-                        The performance metric has been added to the selected KPI. 
-                    </div>
-                </div>
-
             </div>
 
 
@@ -185,7 +168,7 @@
                     Add Custom KPM
                 </button>
                 <button class="btn btn-success btn-sm" (click)="confirmAddMetric()"
-                    [disabled]="!performanceMetricToAdd"><fa-icon [icon]="faPlus" class="me-1"></fa-icon>Add
+                    [disabled]="!performanceMetricToAdd && !customKpmToAdd"><fa-icon [icon]="faPlus" class="me-1"></fa-icon>Add
                     Metric</button>
             </div>
         </div>

--- a/src/app/shared/shared-assessment-forms/neb-forms-accordion/neb-setup-form/performance-metrics-modal/performance-metrics-modal.component.spec.ts
+++ b/src/app/shared/shared-assessment-forms/neb-forms-accordion/neb-setup-form/performance-metrics-modal/performance-metrics-modal.component.spec.ts
@@ -10,6 +10,7 @@ import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { BehaviorSubject } from 'rxjs';
 import { IdbKeyPerformanceIndicator } from 'src/app/models/keyPerformanceIndicator';
 import { getNewIdbNonEnergyBenefit } from 'src/app/models/nonEnergyBenefit';
+import { NgxIndexedDBService } from 'ngx-indexed-db';
 
 describe('PerformanceMetricsModalComponent', () => {
   let component: PerformanceMetricsModalComponent;
@@ -19,6 +20,7 @@ describe('PerformanceMetricsModalComponent', () => {
   let keyPerformanceIndicatorIdbService: Partial<KeyPerformanceIndicatorsIdbService> = {
     keyPerformanceIndicators: new BehaviorSubject<Array<IdbKeyPerformanceIndicator>>([])
   };
+  let dbService: Partial<NgxIndexedDBService> = {}
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -28,6 +30,7 @@ describe('PerformanceMetricsModalComponent', () => {
         { provide: NonEnergyBenefitsIdbService, useValue: nonEnergyBenefitsIdbService },
         { provide: KeyPerformanceMetricImpactsIdbService, useValue: keyPerformanceMetricImpactsIdbService },
         { provide: KeyPerformanceIndicatorsIdbService, useValue: keyPerformanceIndicatorIdbService },
+        { provide: NgxIndexedDBService, useValue: dbService }
       ]
     })
       .compileComponents();

--- a/src/app/shared/shared-assessment-forms/neb-forms-accordion/neb-setup-form/performance-metrics-modal/performance-metrics-modal.component.ts
+++ b/src/app/shared/shared-assessment-forms/neb-forms-accordion/neb-setup-form/performance-metrics-modal/performance-metrics-modal.component.ts
@@ -1,19 +1,24 @@
 import { Component, Input } from '@angular/core';
-import { faAsterisk, faChevronDown, faChevronUp, faMagnifyingGlass, faPlus, faSearchPlus, IconDefinition } from '@fortawesome/free-solid-svg-icons';
-import { firstValueFrom } from 'rxjs';
+import { faAsterisk, faChevronDown, faChevronLeft, faChevronUp, faMagnifyingGlass, faPlus, faScaleUnbalancedFlip, faSearchPlus, IconDefinition } from '@fortawesome/free-solid-svg-icons';
+import { firstValueFrom, Subscription } from 'rxjs';
+import { FacilityIdbService } from 'src/app/indexed-db/facility-idb.service';
 import { KeyPerformanceIndicatorsIdbService } from 'src/app/indexed-db/key-performance-indicators-idb.service';
 import { KeyPerformanceMetricImpactsIdbService } from 'src/app/indexed-db/key-performance-metric-impacts-idb.service';
+import { IdbFacility } from 'src/app/models/facility';
 import { IdbKeyPerformanceIndicator } from 'src/app/models/keyPerformanceIndicator';
 import { getNewIdbKeyPerformanceMetricImpact, IdbKeyPerformanceMetricImpact } from 'src/app/models/keyPerformanceMetricImpact';
 import { IdbNonEnergyBenefit } from 'src/app/models/nonEnergyBenefit';
-import { convertOptionTypeToMetricType, KeyPerformanceMetric, KeyPerformanceMetricOptions, KpmKeywordList } from 'src/app/shared/constants/keyPerformanceMetrics';
+import { convertOptionTypeToMetricType, getCustomKPM, KeyPerformanceMetric, KeyPerformanceMetricOptions, KpmKeywordList } from 'src/app/shared/constants/keyPerformanceMetrics';
 import { NebOption, NebOptions } from 'src/app/shared/constants/nonEnergyBenefitOptions';
+import { LocaleService } from 'src/app/shared/shared-services/locale.service';
+
+import * as bootstrap from 'bootstrap';
 
 @Component({
-    selector: 'app-performance-metrics-modal',
-    templateUrl: './performance-metrics-modal.component.html',
-    styleUrl: './performance-metrics-modal.component.css',
-    standalone: false
+  selector: 'app-performance-metrics-modal',
+  templateUrl: './performance-metrics-modal.component.html',
+  styleUrl: './performance-metrics-modal.component.css',
+  standalone: false
 })
 export class PerformanceMetricsModalComponent {
   @Input({ required: true })
@@ -25,6 +30,7 @@ export class PerformanceMetricsModalComponent {
   faChevronDown: IconDefinition = faChevronDown;
   faChevronUp: IconDefinition = faChevronUp;
   faAsterisk: IconDefinition = faAsterisk;
+  faChevronLeft: IconDefinition = faChevronLeft;
 
   displayMetricsModal: boolean = false;
 
@@ -39,21 +45,103 @@ export class PerformanceMetricsModalComponent {
   kpmKeywordList: string[] = KpmKeywordList;
   filteredKpmKeywordList: string[] = [];
 
+  isCustomKPM: boolean = false;
+  facility: IdbFacility;
+  selectedKpi: IdbKeyPerformanceIndicator;
+  customKpmToAdd: KeyPerformanceMetric;
+  faScaleUnbalancedFlip: IconDefinition = faScaleUnbalancedFlip;
+  facilityKpis: Array<IdbKeyPerformanceIndicator>;
+  currencyCode: string;
+  currencySub: Subscription;
+  showSuccessMsg: boolean = false;
+
   constructor(private keyPerformanceIndicatorIdbService: KeyPerformanceIndicatorsIdbService,
-    private keyPerformanceMetricImpactIdbService: KeyPerformanceMetricImpactsIdbService
+    private keyPerformanceMetricImpactIdbService: KeyPerformanceMetricImpactsIdbService,
+    private localeService: LocaleService,
+    private facilityIdbService: FacilityIdbService
   ) {
 
+  }
+
+  ngOnInit() {
+    this.facility = this.facilityIdbService.selectedFacility.getValue();
+    this.facilityKpis = this.keyPerformanceIndicatorIdbService.getByFacilityGuid(this.facility.guid);
+    this.currencySub = this.localeService.currencyCode.subscribe(code => {
+      this.currencyCode = code;
+    });
+  }
+
+  ngOnDestroy() {
+    this.currencySub.unsubscribe();
   }
 
   openMetricModal() {
     this.keyPerformanceIndicators = this.keyPerformanceIndicatorIdbService.keyPerformanceIndicators.getValue();
     this.displayMetricsModal = true;
     this.setMetricOptions();
+
+    if (bootstrap) {
+      setTimeout(() => {
+        const tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
+        tooltipTriggerList.forEach(function (tooltipTriggerEl) {
+          new bootstrap.Tooltip(tooltipTriggerEl, { container: 'body' });
+        });
+      }, 0);
+    }
   }
 
   closeAddMetricModal() {
     this.displayMetricsModal = false;
     this.performanceMetricToAdd = undefined;
+    this.isCustomKPM = false;
+    this.selectedKpi = undefined;
+    this.customKpmToAdd = undefined;
+  }
+
+  addCustomKPM() {
+    this.isCustomKPM = true;
+  }
+
+  onSelectedKpiChange(selectedKpi: IdbKeyPerformanceIndicator) {
+    this.selectedKpi = selectedKpi;
+    if (this.selectedKpi) {
+      this.customKpmToAdd = getCustomKPM(this.selectedKpi.optionValue, this.selectedKpi.guid);
+    }
+  }
+
+  async saveChanges() {
+    if (this.selectedKpi.optionValue == 'other') {
+      this.selectedKpi.htmlLabel = this.selectedKpi.label;
+    }
+    this.selectedKpi.performanceMetrics.forEach(metric => {
+      if (metric.isCustom) {
+        metric.htmlLabel = metric.label;
+      }
+    });
+    await this.keyPerformanceIndicatorIdbService.asyncUpdate(this.selectedKpi);
+    await this.keyPerformanceIndicatorIdbService.setKeyPerformanceIndicators();
+  }
+
+  async calculateCost(keyPerformanceMetric: KeyPerformanceMetric) {
+    await this.keyPerformanceMetricImpactIdbService.updatePerformanceMetricBaseline(keyPerformanceMetric);
+    await this.saveChanges();
+  }
+
+  addSelectedKpi() {
+    if (this.selectedKpi && this.customKpmToAdd) {
+      this.selectedKpi.performanceMetrics.unshift(this.customKpmToAdd);
+      this.saveChanges();
+      this.showSuccessMsg = true;
+    }
+  }
+
+  goToMetricsList() {
+    this.isCustomKPM = false;
+    this.selectedKpi = undefined;
+    this.customKpmToAdd = undefined;
+    this.showSuccessMsg = false;
+    this.keyPerformanceIndicators = this.keyPerformanceIndicatorIdbService.keyPerformanceIndicators.getValue();
+    this.setMetricOptions();
   }
 
   filterKpmKeywordList() {

--- a/src/app/shared/shared-assessment-forms/neb-forms-accordion/neb-setup-form/performance-metrics-modal/performance-metrics-modal.component.ts
+++ b/src/app/shared/shared-assessment-forms/neb-forms-accordion/neb-setup-form/performance-metrics-modal/performance-metrics-modal.component.ts
@@ -53,7 +53,6 @@ export class PerformanceMetricsModalComponent {
   facilityKpis: Array<IdbKeyPerformanceIndicator>;
   currencyCode: string;
   currencySub: Subscription;
-  showSuccessMsg: boolean = false;
 
   constructor(private keyPerformanceIndicatorIdbService: KeyPerformanceIndicatorsIdbService,
     private keyPerformanceMetricImpactIdbService: KeyPerformanceMetricImpactsIdbService,
@@ -127,23 +126,6 @@ export class PerformanceMetricsModalComponent {
     await this.saveChanges();
   }
 
-  addSelectedKpi() {
-    if (this.selectedKpi && this.customKpmToAdd) {
-      this.selectedKpi.performanceMetrics.unshift(this.customKpmToAdd);
-      this.saveChanges();
-      this.showSuccessMsg = true;
-    }
-  }
-
-  goToMetricsList() {
-    this.isCustomKPM = false;
-    this.selectedKpi = undefined;
-    this.customKpmToAdd = undefined;
-    this.showSuccessMsg = false;
-    this.keyPerformanceIndicators = this.keyPerformanceIndicatorIdbService.keyPerformanceIndicators.getValue();
-    this.setMetricOptions();
-  }
-
   filterKpmKeywordList() {
     const searchStr = this.kpmSearchStr.toLowerCase().trim();
     if (!searchStr) {
@@ -172,6 +154,11 @@ export class PerformanceMetricsModalComponent {
   }
 
   async confirmAddMetric() {
+    if (this.selectedKpi && this.customKpmToAdd) {
+      this.selectedKpi.performanceMetrics.unshift(this.customKpmToAdd);
+      await this.saveChanges();
+      this.performanceMetricToAdd = this.customKpmToAdd;
+    }
     //make sure metric is tracked in KPI
     let addedMetric: KeyPerformanceMetric = await this.keyPerformanceIndicatorIdbService.addKpmToKpi(this.nonEnergyBenefit.companyId, this.performanceMetricToAdd, this.nonEnergyBenefit.userId, this.nonEnergyBenefit.facilityId);
     let keyPerformanceIndicator: IdbKeyPerformanceIndicator = this.keyPerformanceIndicatorIdbService.getKpiFromKpm(this.nonEnergyBenefit.facilityId, this.performanceMetricToAdd.kpiValue);

--- a/src/app/shared/shared-assessment-forms/neb-forms-accordion/neb-setup-form/performance-metrics-modal/performance-metrics-modal.component.ts
+++ b/src/app/shared/shared-assessment-forms/neb-forms-accordion/neb-setup-form/performance-metrics-modal/performance-metrics-modal.component.ts
@@ -64,14 +64,18 @@ export class PerformanceMetricsModalComponent {
 
   ngOnInit() {
     this.facility = this.facilityIdbService.selectedFacility.getValue();
-    this.facilityKpis = this.keyPerformanceIndicatorIdbService.getByFacilityGuid(this.facility.guid);
+    if(this.facility) {
+      this.facilityKpis = this.keyPerformanceIndicatorIdbService.getByFacilityGuid(this.facility.guid);
+    }
     this.currencySub = this.localeService.currencyCode.subscribe(code => {
       this.currencyCode = code;
     });
   }
 
   ngOnDestroy() {
-    this.currencySub.unsubscribe();
+    if (this.currencySub) {
+      this.currencySub.unsubscribe();
+    }
   }
 
   openMetricModal() {

--- a/src/assets/styles/modals.css
+++ b/src/assets/styles/modals.css
@@ -9,6 +9,10 @@
     z-index: 9990;
 }
 
+.tooltip {
+  z-index: 99999 !important; 
+}
+
 .popup {
     border-style: solid;
     border: 1px solid #ffffff;


### PR DESCRIPTION
connects #217 

This pull request introduces a new workflow for adding custom Key Performance Metrics (KPMs) to the performance metrics modal, along with UI and style improvements. The changes allow users to select a KPI, define a custom metric, and add it to the facility's KPI list, enhancing flexibility in metric tracking. Several UI elements and styling have also been refined for better usability and appearance.

**Custom KPM Addition Workflow:**
* Added logic and UI for selecting a KPI and creating a custom KPM, including new form fields and a details component. This enables users to add custom metrics directly to a selected KPI. 
* Updated the `confirmAddMetric` method to support saving custom KPMs and associating them with the selected KPI before final confirmation.

**UI/UX Improvements:**
* Improved modal layout and controls, including a new "Add Custom KPM" button, conditional rendering for custom KPM workflows, and enhanced dropdown and checkbox formatting for better accessibility and clarity. 

These changes collectively enable a more flexible and user-friendly experience when managing performance metrics within the modal.