### PR TITLE
Issue 331: KPM impacts table in reports

### DIFF
--- a/src/app/shared/reports/assessment-report/assessment-report.component.html
+++ b/src/app/shared/reports/assessment-report/assessment-report.component.html
@@ -5,25 +5,31 @@
         <div class="print-break-avoid">
             <app-assessment-savings-chart [assessmentReport]="assessmentReport"></app-assessment-savings-chart>
         </div>
-        <ng-template [ngIf]="assessmentReport.keyPerformanceIndicatorReport.kpiReportItems.length > 0" [ngIfElse]="noKpiReportsBlock">
+        <ng-template [ngIf]="assessmentReport.keyPerformanceIndicatorReport.kpiReportItems.length > 0"
+            [ngIfElse]="noKpiReportsBlock">
             <div class="print-break-avoid">
                 <app-performance-metrics-table
                     [keyPerformanceIndicatorReport]="assessmentReport.keyPerformanceIndicatorReport"></app-performance-metrics-table>
             </div>
             <div class="print-break-avoid">
-                <app-additional-savings-message [assessmentReport]="assessmentReport"
-                    [context]="'assessment'" [includesKpiTable]="true"></app-additional-savings-message>
+                <app-additional-savings-message [assessmentReport]="assessmentReport" [context]="'assessment'"
+                    [includesKpiTable]="true"></app-additional-savings-message>
             </div>
             <div class="print-break-avoid">
                 <app-performance-metrics-chart
                     [keyPerformanceIndicatorReport]="assessmentReport.keyPerformanceIndicatorReport"></app-performance-metrics-chart>
             </div>
+            <div class="print-break-avoid">
+                <app-performance-metrics-impacts-table
+                    [keyPerformanceIndicatorReport]="assessmentReport.keyPerformanceIndicatorReport">
+                </app-performance-metrics-impacts-table>
+            </div>
             <hr>
         </ng-template>
         <ng-template #noKpiReportsBlock>
             <div class="print-break-avoid">
-                <app-additional-savings-message [assessmentReport]="assessmentReport"
-                    [context]="'assessment'" [includesKpiTable]="false"></app-additional-savings-message>
+                <app-additional-savings-message [assessmentReport]="assessmentReport" [context]="'assessment'"
+                    [includesKpiTable]="false"></app-additional-savings-message>
             </div>
         </ng-template>
         <div class="print-break-avoid print-break-before">

--- a/src/app/shared/reports/on-site-visit-report/on-site-visit-report.component.html
+++ b/src/app/shared/reports/on-site-visit-report/on-site-visit-report.component.html
@@ -23,6 +23,10 @@
             <app-performance-metrics-chart
                 [keyPerformanceIndicatorReport]="onSiteVisitReport.keyPerformanceIndicatorReport"></app-performance-metrics-chart>
         </div>
+        <div class="print-break-avoid">
+            <app-performance-metrics-impacts-table
+                [keyPerformanceIndicatorReport]="onSiteVisitReport.keyPerformanceIndicatorReport"></app-performance-metrics-impacts-table>
+        </div>
         <hr>
     </ng-template>
     <ng-template #noKpiReportsBlock>

--- a/src/app/shared/reports/performance-metrics-impacts-table/order-performance-metrics-impacts-table.pipe.spec.ts
+++ b/src/app/shared/reports/performance-metrics-impacts-table/order-performance-metrics-impacts-table.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { OrderPerformanceMetricsImpactsTablePipe } from './order-performance-metrics-impacts-table.pipe';
+
+describe('OrderPerformanceMetricsImpactsTablePipe', () => {
+  it('create an instance', () => {
+    const pipe = new OrderPerformanceMetricsImpactsTablePipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/src/app/shared/reports/performance-metrics-impacts-table/order-performance-metrics-impacts-table.pipe.ts
+++ b/src/app/shared/reports/performance-metrics-impacts-table/order-performance-metrics-impacts-table.pipe.ts
@@ -1,0 +1,18 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import * as _ from 'lodash';
+import { KpmImpactsReportItem, OrderMetricsImpactTableFields } from './performance-metrics-impacts-table.component';
+
+@Pipe({
+  name: 'orderPerformanceMetricsImpactsTable',
+  standalone: false
+})
+export class OrderPerformanceMetricsImpactsTablePipe implements PipeTransform {
+
+  transform(kpiReportItems: Array<KpmImpactsReportItem>, orderByField: OrderMetricsImpactTableFields, orderByDir: 'asc' | 'desc'): Array<KpmImpactsReportItem> {
+    return _.orderBy(kpiReportItems, (item: KpmImpactsReportItem) => {
+      return item[orderByField];
+    }, orderByDir)
+  }
+
+}
+

--- a/src/app/shared/reports/performance-metrics-impacts-table/performance-metrics-impacts-table.component.css
+++ b/src/app/shared/reports/performance-metrics-impacts-table/performance-metrics-impacts-table.component.css
@@ -1,0 +1,14 @@
+.table td, .table th{
+    padding: .25rem;
+    font-size: 14px;
+}
+th fa-icon.ng-fa-icon{
+    display: none;
+}
+th.ordered-th fa-icon.ng-fa-icon{
+    display: inline;
+}
+th:hover{
+    cursor: pointer;
+    text-decoration: underline;
+}

--- a/src/app/shared/reports/performance-metrics-impacts-table/performance-metrics-impacts-table.component.html
+++ b/src/app/shared/reports/performance-metrics-impacts-table/performance-metrics-impacts-table.component.html
@@ -1,0 +1,57 @@
+<h6 class="bold">Key Performance Metric Impacts</h6>
+<table class="table table-bordered savings-table table-hover ordered" *ngIf="keyPerformanceIndicatorReport">
+    <thead>
+        <tr>
+            <th class="bg-neutral" (click)="setOrderByField('label')"
+                [ngClass]="{'ordered-th': orderByField == 'label'}">
+                Performance Metric
+            </th>
+            <th class="text-right bg-without-nebs" (click)="setOrderByField('current')"
+                [ngClass]="{'ordered-th': orderByField == 'current'}">
+                Current
+            </th>
+            <th class="text-right bg-with-nebs" (click)="setOrderByField('impact')"
+                [ngClass]="{'ordered-th': orderByField == 'impact'}">
+                Impact
+            </th>
+            <th class="text-right bg-with-nebs" (click)="setOrderByField('potential')"
+                [ngClass]="{'ordered-th': orderByField == 'potential'}">
+                Potential
+            </th>
+            <th class="text-right bg-with-nebs" (click)="setOrderByField('percentChange')"
+                [ngClass]="{'ordered-th': orderByField == 'percentChange'}">
+                Change (%)
+            </th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr *ngFor="let kpmReportItem of kpmImpactsReports | orderPerformanceMetricsImpactsTable: orderByField : orderByDir">
+            <td class="ps-3 bg-neutral-light">
+                <span [innerHTML]="kpmReportItem.label"></span>
+            </td>
+            @let units = kpmReportItem.isCurrency ? undefined : kpmReportItem.units;
+            <td class="text-right bg-without-nebs-light">
+                <app-single-cell-item [numValue]="kpmReportItem.current" [isCurrency]="kpmReportItem.isCurrency"
+                    [units]="units"></app-single-cell-item>
+            </td>
+            <td class="text-right bg-with-nebs-light">
+                <ng-container *ngIf="kpmReportItem.goalToIncrease">
+                    &plus;
+                </ng-container>
+                <ng-container *ngIf="!kpmReportItem.goalToIncrease">
+                    &minus;
+                </ng-container>
+                <app-single-cell-item [numValue]="kpmReportItem.impact" [isCurrency]="kpmReportItem.isCurrency"
+                    [units]="units"></app-single-cell-item>
+            </td>
+            <td class="text-right bg-with-nebs-light">
+                <app-single-cell-item [numValue]="kpmReportItem.potential" [isCurrency]="kpmReportItem.isCurrency"
+                    [units]="units"></app-single-cell-item>
+            </td>
+            <td class="text-right bg-with-nebs-light">
+                <app-single-cell-item [numValue]="kpmReportItem.percentChange" [isCurrency]="false"
+                    [units]="'%'"></app-single-cell-item>
+            </td>
+
+        </tr>
+</table>

--- a/src/app/shared/reports/performance-metrics-impacts-table/performance-metrics-impacts-table.component.spec.ts
+++ b/src/app/shared/reports/performance-metrics-impacts-table/performance-metrics-impacts-table.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PerformanceMetricsImpactsTableComponent } from './performance-metrics-impacts-table.component';
+
+describe('PerformanceMetricsImpactsTableComponent', () => {
+  let component: PerformanceMetricsImpactsTableComponent;
+  let fixture: ComponentFixture<PerformanceMetricsImpactsTableComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [PerformanceMetricsImpactsTableComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(PerformanceMetricsImpactsTableComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/reports/performance-metrics-impacts-table/performance-metrics-impacts-table.component.spec.ts
+++ b/src/app/shared/reports/performance-metrics-impacts-table/performance-metrics-impacts-table.component.spec.ts
@@ -1,6 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { PerformanceMetricsImpactsTableComponent } from './performance-metrics-impacts-table.component';
+import { TableEntriesModule } from '../../table-entries/table-entries.module';
+import { stubServiceProviders } from 'src/app/spec-helpers/spec-test-service-stub';
 
 describe('PerformanceMetricsImpactsTableComponent', () => {
   let component: PerformanceMetricsImpactsTableComponent;
@@ -8,7 +10,9 @@ describe('PerformanceMetricsImpactsTableComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [PerformanceMetricsImpactsTableComponent]
+      imports: [TableEntriesModule],
+      declarations: [PerformanceMetricsImpactsTableComponent],
+      providers: stubServiceProviders
     })
     .compileComponents();
 

--- a/src/app/shared/reports/performance-metrics-impacts-table/performance-metrics-impacts-table.component.ts
+++ b/src/app/shared/reports/performance-metrics-impacts-table/performance-metrics-impacts-table.component.ts
@@ -81,15 +81,15 @@ export class PerformanceMetricsImpactsTableComponent {
           }
         } else if (reportItem.keyPerformanceMetric.calculationMethod == 'percentTotal') {
           impact = reportItem.keyPerformanceMetric.baselineCost - reportItem.performanceMetricImpact.modifiedCost
-        } else {
-          if (goalToIncrease) {
-
-          } else {
-
-          }
         }
         let percentChange: number = (impact / baselineValue) * 100;
-
+        if (percentChange > 10) {
+          //round to 1 decimal place if over 10%
+          percentChange = Number(percentChange.toFixed(1));
+        } else {
+          //round to 2 decimal places if under 10%
+          percentChange = Number(percentChange.toFixed(2));
+        }
 
         this.kpmImpactsReports.push({
           label: reportItem.keyPerformanceMetric.htmlLabel,

--- a/src/app/shared/reports/performance-metrics-impacts-table/performance-metrics-impacts-table.component.ts
+++ b/src/app/shared/reports/performance-metrics-impacts-table/performance-metrics-impacts-table.component.ts
@@ -1,0 +1,121 @@
+import { Component, Input, SimpleChanges } from '@angular/core';
+import { KeyPerformanceIndicatorReport, KeyPerformanceMetricReportItem } from '../calculations/keyPerformanceIndicatorReport';
+import { Subscription } from 'rxjs';
+import { LocaleService } from '../../shared-services/locale.service';
+import { PowerpointReportGeneratorService } from '../../shared-services/powerpoint-report-generator.service';
+
+@Component({
+  selector: 'app-performance-metrics-impacts-table',
+  standalone: false,
+
+  templateUrl: './performance-metrics-impacts-table.component.html',
+  styleUrl: './performance-metrics-impacts-table.component.css'
+})
+export class PerformanceMetricsImpactsTableComponent {
+  @Input({ required: true })
+  keyPerformanceIndicatorReport: KeyPerformanceIndicatorReport;
+
+  orderByDir: 'asc' | 'desc' = 'desc';
+  orderByField: OrderMetricsImpactTableFields = 'percentChange';
+
+  currencyCode: string;
+  currencySub: Subscription;
+
+  kpmImpactsReports: Array<KpmImpactsReportItem>;
+  constructor(
+    private localeService: LocaleService,
+    private powerpointReportGeneratorService: PowerpointReportGeneratorService
+
+  ) { }
+
+  ngOnInit() {
+    this.currencySub = this.localeService.currencyCode.subscribe(code => {
+      this.currencyCode = code;
+    });
+    this.setReports();
+  }
+
+  ngOnDestroy() {
+    this.currencySub.unsubscribe();
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes['keyPerformanceIndicatorReport'] && !changes['keyPerformanceIndicatorReport'].firstChange) {
+      this.setReports();
+    }
+  }
+
+  setOrderByField(orderByField: OrderMetricsImpactTableFields) {
+    if (orderByField == this.orderByField) {
+      this.toggleOrderBy();
+    } else {
+      this.orderByField = orderByField;
+    }
+    this.powerpointReportGeneratorService.setOrder(this.orderByDir, this.orderByField);
+  }
+
+  toggleOrderBy() {
+    if (this.orderByDir == 'asc') {
+      this.orderByDir = 'desc';
+    } else {
+      this.orderByDir = 'asc';
+    }
+  }
+
+  setReports() {
+    this.kpmImpactsReports = new Array();
+    if (this.keyPerformanceIndicatorReport) {
+      this.keyPerformanceIndicatorReport.kpmReportItems.forEach(reportItem => {
+        let isCurrency: boolean = true;
+        let baselineValue: number = reportItem.keyPerformanceMetric.baselineCost;
+        let impact: number = reportItem.performanceMetricImpact.modificationValue;
+        let goalToIncrease: boolean = reportItem.keyPerformanceMetric.goalToIncrease;
+        let potential: number = reportItem.performanceMetricImpact.modifiedCost;
+        if (reportItem.keyPerformanceMetric.calculationMethod == 'costPerUnit') {
+          isCurrency = false;
+          baselineValue = reportItem.keyPerformanceMetric.baselineValue;
+          if (goalToIncrease) {
+            potential = reportItem.keyPerformanceMetric.baselineValue + reportItem.performanceMetricImpact.modificationValue;
+          } else {
+            potential = reportItem.keyPerformanceMetric.baselineValue - reportItem.performanceMetricImpact.modificationValue;
+          }
+        } else if (reportItem.keyPerformanceMetric.calculationMethod == 'percentTotal') {
+          impact = reportItem.keyPerformanceMetric.baselineCost - reportItem.performanceMetricImpact.modifiedCost
+        } else {
+          if (goalToIncrease) {
+
+          } else {
+
+          }
+        }
+        let percentChange: number = (impact / baselineValue) * 100;
+
+
+        this.kpmImpactsReports.push({
+          label: reportItem.keyPerformanceMetric.htmlLabel,
+          current: baselineValue,
+          impact: impact,
+          potential: potential,
+          percentChange: percentChange,
+          units: reportItem.keyPerformanceMetric.totalUnit,
+          isCurrency: isCurrency,
+          goalToIncrease: reportItem.keyPerformanceMetric.goalToIncrease
+        })
+      });
+    }
+  }
+}
+
+
+export interface KpmImpactsReportItem {
+  label: string,
+  current: number,
+  impact: number,
+  potential: number,
+  percentChange: number,
+  units: string,
+  isCurrency: boolean,
+  goalToIncrease: boolean
+}
+
+export type OrderMetricsImpactTableFields = 'current' | 'impact' | 'potential' | 'percentChange' | 'label'

--- a/src/app/shared/reports/reports.module.ts
+++ b/src/app/shared/reports/reports.module.ts
@@ -25,6 +25,8 @@ import { AssessmentCostTableComponent } from './assessment-report/assessment-cos
 import { ExecutiveSummaryProjectSummaryComponent } from './executive-summary-report/executive-summary-project-summary/executive-summary-project-summary.component';
 import { ExecutiveSummaryKpiImpactsComponent } from './executive-summary-report/executive-summary-kpi-impacts/executive-summary-kpi-impacts.component';
 import { AdditionalSavingsMessageComponent } from './additional-savings-message/additional-savings-message.component';
+import { PerformanceMetricsImpactsTableComponent } from './performance-metrics-impacts-table/performance-metrics-impacts-table.component';
+import { OrderPerformanceMetricsImpactsTablePipe } from './performance-metrics-impacts-table/order-performance-metrics-impacts-table.pipe';
 
 
 
@@ -50,7 +52,9 @@ import { AdditionalSavingsMessageComponent } from './additional-savings-message/
     AssessmentCostTableComponent,
     ExecutiveSummaryProjectSummaryComponent,
     ExecutiveSummaryKpiImpactsComponent,
-    AdditionalSavingsMessageComponent
+    AdditionalSavingsMessageComponent,
+    PerformanceMetricsImpactsTableComponent,
+    OrderPerformanceMetricsImpactsTablePipe
   ],
   imports: [
     CommonModule,


### PR DESCRIPTION
connects #331 

This pull request introduces a new `PerformanceMetricsImpactsTableComponent` to display key performance metric impacts in both the assessment and on-site visit reports. The component includes sorting functionality and is fully integrated into the existing report templates. Supporting code, styles, and tests are also added to ensure maintainability and usability.

**Component Addition and Integration:**

* Added the new `PerformanceMetricsImpactsTableComponent` to visualize key performance metric impacts, including sorting and formatting logic.
* Integrated the new component into the assessment and on-site visit report templates so that it appears alongside other performance metrics visualizations. [[1]](diffhunk://#diff-e8645d789f8e84221e9e5abb1c60f6318194b9855799b0b55fde58a42665eea8L8-R32) [[2]](diffhunk://#diff-bb0cf55da30b122a2f7e19104278ff350b23ec63c22537d37d8fe0a15e4e4b11R26-R29)
* Registered the new component and its supporting pipe in the `reports.module.ts` declarations and imports. [[1]](diffhunk://#diff-393153cc2a2fe3c7f070c05099391a0ab26be07f1c9497cb96b5fedd431fdd2cR28-R29) [[2]](diffhunk://#diff-393153cc2a2fe3c7f070c05099391a0ab26be07f1c9497cb96b5fedd431fdd2cL53-R57)

**Sorting and Presentation Enhancements:**

* Implemented `OrderPerformanceMetricsImpactsTablePipe` to enable sorting of metric impact items in the new table by any column, with a corresponding test. [[1]](diffhunk://#diff-91a4b6b6d7374b7d8ea03188f525d2f60decddb576212fe50cc5c9958b4621e5R1-R18) [[2]](diffhunk://#diff-58da5ab13ba389d269e29d7ed12f0eebf817729b28a4e6a75d9b62b358c33131R1-R8)
* Added styles and an interactive table header to visually indicate and allow users to change the sort order. [[1]](diffhunk://#diff-ddd7ef5ec345ff3705d96d2cd2cd1875fba37e95ae7a050d3155126e11e83288R1-R14) [[2]](diffhunk://#diff-fa17d34967788a75cb8fbf35e2b43115dc7ad54d4a2c1a5f710a9e2f5f33f3c7R1-R57)

**Testing:**

* Added unit tests for both the new component and its sorting pipe to ensure correctness and future reliability. [[1]](diffhunk://#diff-348344f4d7ac2ef9ad5ff899b651798ab3d3c545816d86811e54107f1d729c81R1-R23) [[2]](diffhunk://#diff-58da5ab13ba389d269e29d7ed12f0eebf817729b28a4e6a75d9b62b358c33131R1-R8)