### PR TITLE
Issue 561 - changed default for industrial equipment type to blank

### DIFF
--- a/src/app/models/energyEquipment.ts
+++ b/src/app/models/energyEquipment.ts
@@ -68,7 +68,7 @@ export function getNewIdbEnergyEquipment(userId: string, companyId: string, faci
         companyId: companyId,
         facilityId: facilityId,
         equipmentName: 'New Industrial Equipment',
-        equipmentType: "Pump",
+        equipmentType: undefined,
         utilityType: "Electricity",
         size: 0,
         sizeUnit: "kW",


### PR DESCRIPTION
connects #561 

This pull request makes a small change to the default values when creating new industrial energy equipment. The `equipmentType` is now set to `undefined` instead of `"Pump"` in the `getNewIdbEnergyEquipment` function.