### PR TITLE
Issue 327: KPM Impacts Calculation Method

### DIFF
--- a/src/app/indexed-db/key-performance-metric-impacts-idb.service.ts
+++ b/src/app/indexed-db/key-performance-metric-impacts-idb.service.ts
@@ -85,11 +85,11 @@ export class KeyPerformanceMetricImpactsIdbService {
     let facilityMetricImpacts: Array<IdbKeyPerformanceMetricImpact> = this.getByKpmGuid(keyPerformanceMetric.guid);
     for (let i = 0; i < facilityMetricImpacts.length; i++) {
       let metricImpact: IdbKeyPerformanceMetricImpact = facilityMetricImpacts[i];
-      if (keyPerformanceMetric.calculationMethod == 'costPerUnit') {
+      if (metricImpact.calculationMethod == 'costPerUnit') {
         metricImpact.costAdjustment = (metricImpact.modificationValue * keyPerformanceMetric.costPerValue);
-      } else if (keyPerformanceMetric.calculationMethod == 'percentTotal') {
+      } else if (metricImpact.calculationMethod == 'percentTotal') {
         metricImpact.costAdjustment = keyPerformanceMetric.baselineCost * (metricImpact.modificationValue / 100);
-      } else if(keyPerformanceMetric.calculationMethod == 'directCost'){
+      } else if(metricImpact.calculationMethod == 'directCost'){
         metricImpact.costAdjustment = metricImpact.modificationValue;
       }
       await firstValueFrom(this.updateWithObservable(metricImpact));

--- a/src/app/indexed-db/update-db-entries.service.ts
+++ b/src/app/indexed-db/update-db-entries.service.ts
@@ -63,6 +63,7 @@ export class UpdateDbEntriesService {
     }
     this.localeService.setCurrencyCode(user.locale);
 
+    await this.updateMetricImpactCalculationMethods();
     await this.updateProcessEquipment();
     await this.updateEnergyEquipment();
     await this.updateCompanies();
@@ -359,5 +360,27 @@ export class UpdateDbEntriesService {
         needUpdate = false;
       }
     }
+  }
+
+  async updateMetricImpactCalculationMethods() {
+    let keyPerformanceMetricImpacts: Array<IdbKeyPerformanceMetricImpact> = await firstValueFrom(this.keyPerformanceMetricImpactsIdbService.getAll());
+    let keyPerformanceIndicators: Array<IdbKeyPerformanceIndicator> = await firstValueFrom(this.keyPerformanceIndicatorsIdbService.getAll());
+    let keyPerformanceMetrics: Array<KeyPerformanceMetric> = keyPerformanceIndicators.flatMap(kpi => { return kpi.performanceMetrics });
+    let needUpdate = false;
+    for (let i = 0; i < keyPerformanceMetricImpacts.length; i++) {
+      let impact: IdbKeyPerformanceMetricImpact = keyPerformanceMetricImpacts[i];
+      if (impact.calculationMethod == undefined) {
+        let kpm: KeyPerformanceMetric = keyPerformanceMetrics.find(metric => { return metric.guid == impact.kpmGuid });
+        if (kpm) {
+          impact.calculationMethod = kpm.calculationMethod;
+          needUpdate = true;
+        }
+      }
+      if (needUpdate) {
+        await firstValueFrom(this.keyPerformanceMetricImpactsIdbService.updateWithObservable(impact));
+        needUpdate = false;
+      }
+    }
+
   }
 }

--- a/src/app/models/keyPerformanceMetricImpact.ts
+++ b/src/app/models/keyPerformanceMetricImpact.ts
@@ -1,4 +1,4 @@
-import { KeyPerformanceMetricValue } from "../shared/constants/keyPerformanceMetrics";
+import { KeyPerformanceMetricValue, KpmCalculationMethod } from "../shared/constants/keyPerformanceMetrics";
 import { IdbEntry, getNewIdbEntry } from "./idbEntry";
 
 export interface IdbKeyPerformanceMetricImpact extends IdbEntry {
@@ -14,11 +14,12 @@ export interface IdbKeyPerformanceMetricImpact extends IdbEntry {
     modificationValue: number,
     costAdjustment: number,
     percentSavings?: number,
-    modifiedCost?: number
+    modifiedCost?: number,
+    calculationMethod: KpmCalculationMethod
 }
 
 
-export function getNewIdbKeyPerformanceMetricImpact(userId: string, companyId: string, facilityId: string, energyOpportunityId: string, nebId: string, kpmValue: KeyPerformanceMetricValue, assessmentId: string, kpiGuid: string, kpmGuid: string): IdbKeyPerformanceMetricImpact {
+export function getNewIdbKeyPerformanceMetricImpact(userId: string, companyId: string, facilityId: string, energyOpportunityId: string, nebId: string, kpmValue: KeyPerformanceMetricValue, assessmentId: string, kpiGuid: string, kpmGuid: string, calculationMethod: KpmCalculationMethod): IdbKeyPerformanceMetricImpact {
     let idbEntry: IdbEntry = getNewIdbEntry();
     return {
         ...idbEntry,
@@ -34,6 +35,7 @@ export function getNewIdbKeyPerformanceMetricImpact(userId: string, companyId: s
         percentSavings: undefined,
         modifiedCost: undefined,
         kpmValue: kpmValue,
-        kpmGuid: kpmGuid
+        kpmGuid: kpmGuid,
+        calculationMethod: calculationMethod
     }
 }

--- a/src/app/shared/kpm-details-form/kpm-details-form.component.html
+++ b/src/app/shared/kpm-details-form/kpm-details-form.component.html
@@ -35,9 +35,9 @@
             Calculation Method
         </label> -->
         <div class="col-sm-6 col-form-label">
-            <app-label-with-tooltip [field]="'calculationMethod'"
+            <app-label-with-tooltip [field]="'calculationMethodBaseline'"
                 [labelId]="'calculationMethod_'+keyPerformanceMetric.value"
-                [label]="'Impact Calculation Method'"></app-label-with-tooltip>
+                [label]="'Baseline Calculation Method'"></app-label-with-tooltip>
         </div>
         <div class="col-6">
             <select id="{{'calculationMethod_'+keyPerformanceMetric.value}}"

--- a/src/app/shared/kpm-details-form/kpm-details-form.component.html
+++ b/src/app/shared/kpm-details-form/kpm-details-form.component.html
@@ -46,7 +46,6 @@
                 [disabled]="disableForm">
                 <option [ngValue]="'costPerUnit'">Per Unit</option>
                 <option [ngValue]="'directCost'">Direct Impact</option>
-                <option [ngValue]="'percentTotal'">Percent Total</option>
             </select>
         </div>
     </div>

--- a/src/app/shared/label-with-tooltip/LabelTooltips.ts
+++ b/src/app/shared/label-with-tooltip/LabelTooltips.ts
@@ -11,6 +11,9 @@ export const LabelTooltips = {
     "calculationMethod": {
         "tooltip": "The method used to calculate impacts on the metric."
     },
+    "calculationMethodBaseline": {
+        "tooltip": "The method used to calculate the baseline metric value."
+    },
     "associatedEEM": {
         "tooltip": "Is this NEB realized because of the implementation of a specific energy efficiency measure?"
     },

--- a/src/app/shared/shared-assessment-forms/add-nebs-modal/add-nebs-modal.component.ts
+++ b/src/app/shared/shared-assessment-forms/add-nebs-modal/add-nebs-modal.component.ts
@@ -72,7 +72,7 @@ export class AddNebsModalComponent {
         let keyPerformanceMetric: KeyPerformanceMetric = convertOptionTypeToMetricType(performanceMetricToAdd)
         let addedMetric: KeyPerformanceMetric = await this.keyPerformanceIndicatorIdbService.addKpmToKpi(newIdbNonEnergyBenefit.companyId, keyPerformanceMetric, newIdbNonEnergyBenefit.userId, newIdbNonEnergyBenefit.facilityId);
         let keyPerformanceIndicator: IdbKeyPerformanceIndicator = this.keyPerformanceIndicatorIdbService.getKpiFromKpm(newIdbNonEnergyBenefit.facilityId, performanceMetricToAdd.kpiValue);
-        let newKeyPerformanceMetricImpact: IdbKeyPerformanceMetricImpact = getNewIdbKeyPerformanceMetricImpact(newIdbNonEnergyBenefit.userId, newIdbNonEnergyBenefit.companyId, newIdbNonEnergyBenefit.facilityId, newIdbNonEnergyBenefit.energyOpportunityId, newIdbNonEnergyBenefit.guid, addedMetric.value, newIdbNonEnergyBenefit.assessmentId, keyPerformanceIndicator.guid, addedMetric.guid);
+        let newKeyPerformanceMetricImpact: IdbKeyPerformanceMetricImpact = getNewIdbKeyPerformanceMetricImpact(newIdbNonEnergyBenefit.userId, newIdbNonEnergyBenefit.companyId, newIdbNonEnergyBenefit.facilityId, newIdbNonEnergyBenefit.energyOpportunityId, newIdbNonEnergyBenefit.guid, addedMetric.value, newIdbNonEnergyBenefit.assessmentId, keyPerformanceIndicator.guid, addedMetric.guid, addedMetric.calculationMethod);
         await firstValueFrom(this.keyPerformanceMetricImpactsIdbService.addWithObservable(newKeyPerformanceMetricImpact));
         await this.keyPerformanceMetricImpactsIdbService.setKeyPerformanceMetricImpacts();
         let onSiteVisit: IdbOnSiteVisit = this.onSiteVisitIdbService.getByAssessmentGUID(newKeyPerformanceMetricImpact.assessmentId);

--- a/src/app/shared/shared-assessment-forms/neb-forms-accordion/neb-setup-form/performance-metric-impact-form/performance-metric-impact-form.component.html
+++ b/src/app/shared/shared-assessment-forms/neb-forms-accordion/neb-setup-form/performance-metric-impact-form/performance-metric-impact-form.component.html
@@ -74,7 +74,7 @@
                 </div>
                 <div class="row">
                     <div class="col-sm-6 col-form-label">
-                        <app-label-with-tooltip [field]="'calculationMethod'"
+                        <app-label-with-tooltip [field]="'calculationMethodBaseline'"
                             [labelId]="'calculationMethod_'+keyPerformanceMetric.value"
                             [label]="'Baseline Calculation Method'"></app-label-with-tooltip>
                     </div>

--- a/src/app/shared/shared-assessment-forms/neb-forms-accordion/neb-setup-form/performance-metric-impact-form/performance-metric-impact-form.component.html
+++ b/src/app/shared/shared-assessment-forms/neb-forms-accordion/neb-setup-form/performance-metric-impact-form/performance-metric-impact-form.component.html
@@ -54,13 +54,157 @@
             </div>
         </div>
         <div class="form-block">
-            <app-kpm-details-form [keyPerformanceMetric]="keyPerformanceMetric"
-                [disableForm]="(metricHasOtherImpacts && !overrideBaseline)" (emitSave)="savePerformanceMetric()"
-                (emitCalculate)="calculateCostFromKPM($event)" [context]="'onSite'"
-                [currencyCode]="currencyCode"></app-kpm-details-form>
-
-
             <ng-template [ngIf]="keyPerformanceMetric.isQuantitative">
+                <!--KPM Baseline Details-->
+                <div class="row">
+                    <div class="col-sm-6 col-form-label">
+                        <app-label-with-tooltip [field]="'goalToIncrease'"
+                            [labelId]="'goalToIncrease_'+keyPerformanceMetric.value"
+                            [label]="'Expected Impact'"></app-label-with-tooltip>
+                    </div>
+                    <div class="col-6">
+                        <select id="{{'goalToIncrease_'+keyPerformanceMetric.value}}"
+                            name="{{'goalToIncrease_'+keyPerformanceMetric.value}}" class="form-select"
+                            [(ngModel)]="keyPerformanceMetric.goalToIncrease" (change)="calculateBaselineCost(false)"
+                            [disabled]="(metricHasOtherImpacts && !overrideBaseline)">
+                            <option [ngValue]="true">Increase Revenues</option>
+                            <option [ngValue]="false">Decrease Costs</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-sm-6 col-form-label">
+                        <app-label-with-tooltip [field]="'calculationMethod'"
+                            [labelId]="'calculationMethod_'+keyPerformanceMetric.value"
+                            [label]="'Baseline Calculation Method'"></app-label-with-tooltip>
+                    </div>
+                    <div class="col-6">
+                        <select id="{{'calculationMethod_'+keyPerformanceMetric.value}}"
+                            name="{{'calculationMethod_'+keyPerformanceMetric.value}}" class="form-select"
+                            [(ngModel)]="keyPerformanceMetric.calculationMethod" (change)="calculateBaselineCost(true)"
+                            [disabled]="(metricHasOtherImpacts && !overrideBaseline)">
+                            <option [ngValue]="'costPerUnit'">Per Unit</option>
+                            <option [ngValue]="'directCost'">Direct Impact</option>
+                        </select>
+                    </div>
+                </div>
+
+                <!--COST PER UNIT-->
+                <ng-template [ngIf]="keyPerformanceMetric.calculationMethod == 'costPerUnit'">
+                    <div class="row">
+                        <label class="col-sm-6 col-form-label" for="{{'totalUnit_'+keyPerformanceMetric.value}}">
+                            Unit
+                        </label>
+                        <div class="col-6">
+                            <div class="input-group">
+                                <input type="text" class="form-control" [(ngModel)]="keyPerformanceMetric.totalUnit"
+                                    name="{{'totalUnit_'+keyPerformanceMetric.value}}"
+                                    [disabled]="(metricHasOtherImpacts && !overrideBaseline)"
+                                    (input)="calculateBaselineCost(false)">
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <label class="col-sm-6 col-form-label" for="{{'baselineValue_'+keyPerformanceMetric.value}}">
+                            Baseline Amount
+                        </label>
+                        <div class="col-6">
+                            <div class="input-group">
+                                <input type="number" class="form-control"
+                                    [(ngModel)]="keyPerformanceMetric.baselineValue"
+                                    name="{{'baselineValue_'+keyPerformanceMetric.value}}"
+                                    [disabled]="(metricHasOtherImpacts && !overrideBaseline)" min="0"
+                                    (input)="calculateBaselineCost(false)">
+                                <span class="input-group-text">
+                                    <span [innerHTML]="keyPerformanceMetric.totalUnit | unitsDisplay"></span>/yr
+                                </span>
+                            </div>
+                            <div class="alert alert-warning form-error" *ngIf="keyPerformanceMetric.baselineValue < 0">
+                                Value should not be negative.
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="row">
+                        <label class="col-sm-6 col-form-label" for="{{'costPerValue_'+keyPerformanceMetric.value}}">
+                            Per Unit
+                        </label>
+                        <div class="col-6">
+                            <div class="input-group">
+                                <input type="number" class="form-control"
+                                    [(ngModel)]="keyPerformanceMetric.costPerValue"
+                                    name="{{'costPerValue_'+keyPerformanceMetric.value}}"
+                                    [disabled]="(metricHasOtherImpacts && !overrideBaseline)" min="0"
+                                    (input)="calculateBaselineCost(true)">
+                                <span class="input-group-text">
+                                    {{ currencyCode | currencySymbol }}/<span
+                                        [innerHTML]="keyPerformanceMetric.totalUnit | unitsDisplay"></span>
+                                </span>
+                            </div>
+                            <div class="alert alert-warning form-error" *ngIf="keyPerformanceMetric.costPerValue < 0">
+                                Value should not be negative.
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="row">
+                        <label class="col-sm-6 col-form-label" for="{{'baselineCost_'+keyPerformanceMetric.value}}">
+                            {{ keyPerformanceMetric.goalToIncrease ? 'Baseline Revenue' : 'Baseline Cost' }}
+                        </label>
+                        <div class="col-6">
+                            <ng-template [ngIf]="keyPerformanceMetric.baselineCost" [ngIfElse]="noCostBlock">
+                                {{keyPerformanceMetric.baselineCost | currency:currencyCode}}/yr
+                            </ng-template>
+                            <ng-template #noCostBlock>
+                                &mdash;
+                            </ng-template>
+                        </div>
+                    </div>
+                </ng-template>
+                <!--DIRECT COST or PERCENT-->
+                <ng-template [ngIf]="keyPerformanceMetric.calculationMethod != 'costPerUnit'">
+                    <div class="row">
+                        <label class="col-sm-6 col-form-label" for="{{'baselineCost_'+keyPerformanceMetric.value}}">
+                            {{ keyPerformanceMetric.goalToIncrease ? 'Baseline Revenue' : 'Baseline Cost' }}
+                        </label>
+                        <div class="col-6">
+                            <div class="input-group">
+                                <input type="number" class="form-control"
+                                    [(ngModel)]="keyPerformanceMetric.baselineCost"
+                                    name="{{'baselineCost_'+keyPerformanceMetric.value}}"
+                                    [disabled]="(metricHasOtherImpacts && !overrideBaseline)" min="0"
+                                    (input)="calculateBaselineCost(false)">
+                                <span class="input-group-text">
+                                    {{ currencyCode | currencySymbol }}/yr
+                                </span>
+                            </div>
+                            <div class="alert alert-warning form-error" *ngIf="keyPerformanceMetric.baselineCost < 0">
+                                Value should not be negative.
+                            </div>
+                        </div>
+                    </div>
+                </ng-template>
+                <!--END KPM Details-->
+
+                <div class="row">
+                    <div class="col-sm-6 col-form-label">
+                        <app-label-with-tooltip [field]="'calculationMethod'"
+                            [labelId]="'calculationMethod_'+keyPerformanceMetricImpact.guid"
+                            [label]="'Impact Calculation Method'"></app-label-with-tooltip>
+                    </div>
+                    <div class="col-6">
+                        <select id="{{'calculationMethod_'+keyPerformanceMetricImpact.guid}}"
+                            name="{{'calculationMethod_'+keyPerformanceMetricImpact.guid}}" class="form-select"
+                            [(ngModel)]="keyPerformanceMetricImpact.calculationMethod" (change)="calculateCost()">
+                            @if(keyPerformanceMetric.calculationMethod == 'costPerUnit'){
+                            <option [ngValue]="'costPerUnit'">Per Unit</option>
+                            }
+                            <option [ngValue]="'directCost'">Direct Impact</option>
+                            <option [ngValue]="'percentTotal'">Percent Total</option>
+                        </select>
+                    </div>
+                </div>
+
                 <div class="row">
                     <label class="col-sm-6 col-form-label" for="modificationValue">
                         Impact on KPM
@@ -79,13 +223,13 @@
                                 [(ngModel)]="keyPerformanceMetricImpact.modificationValue" name="modificationValue"
                                 (input)="calculateCost()">
                             <span class="input-group-text">
-                                <ng-template [ngIf]="keyPerformanceMetric.calculationMethod == 'costPerUnit'">
+                                <ng-template [ngIf]="keyPerformanceMetricImpact.calculationMethod == 'costPerUnit'">
                                     <span [innerHTML]="keyPerformanceMetric.totalUnit | unitsDisplay"></span>/yr
                                 </ng-template>
-                                <ng-template [ngIf]="keyPerformanceMetric.calculationMethod == 'directCost'">
+                                <ng-template [ngIf]="keyPerformanceMetricImpact.calculationMethod == 'directCost'">
                                     {{ currencyCode | currencySymbol }}/yr
                                 </ng-template>
-                                <ng-template [ngIf]="keyPerformanceMetric.calculationMethod == 'percentTotal'">
+                                <ng-template [ngIf]="keyPerformanceMetricImpact.calculationMethod == 'percentTotal'">
                                     &percnt;
                                 </ng-template>
                             </span>
@@ -93,7 +237,7 @@
                     </div>
                 </div>
 
-                <div class="row" *ngIf="keyPerformanceMetric.calculationMethod != 'directCost'">
+                <div class="row" *ngIf="keyPerformanceMetricImpact.calculationMethod != 'directCost'">
                     <label class="col-sm-6 col-form-label" for="costPerValue">
                         Financial Impact
                     </label>

--- a/src/app/shared/shared-assessment-forms/neb-forms-accordion/neb-setup-form/performance-metric-impact-form/performance-metric-impact-form.component.ts
+++ b/src/app/shared/shared-assessment-forms/neb-forms-accordion/neb-setup-form/performance-metric-impact-form/performance-metric-impact-form.component.ts
@@ -14,10 +14,10 @@ import { KeyPerformanceMetric } from 'src/app/shared/constants/keyPerformanceMet
 import { LocaleService } from 'src/app/shared/shared-services/locale.service';
 
 @Component({
-    selector: 'app-performance-metric-impact-form',
-    templateUrl: './performance-metric-impact-form.component.html',
-    styleUrl: './performance-metric-impact-form.component.css',
-    standalone: false
+  selector: 'app-performance-metric-impact-form',
+  templateUrl: './performance-metric-impact-form.component.html',
+  styleUrl: './performance-metric-impact-form.component.css',
+  standalone: false
 })
 export class PerformanceMetricImpactFormComponent {
   @Input({ required: true })
@@ -96,23 +96,37 @@ export class PerformanceMetricImpactFormComponent {
     await this.keyPerformanceMetricImpactIdbService.asyncUpdate(this.keyPerformanceMetricImpact);
   }
 
-  calculateCostFromKPM(kpmChanges: {modifiedMethod: boolean, updateBaseline: boolean}){
-    if(kpmChanges.modifiedMethod){
-      this.keyPerformanceMetricImpact.modificationValue = undefined;
+  async calculateBaselineCost(modifiedMethod: boolean) {
+    if (this.keyPerformanceMetric.calculationMethod == 'costPerUnit') {
+      this.keyPerformanceMetric.baselineCost = (this.keyPerformanceMetric.costPerValue * this.keyPerformanceMetric.baselineValue);
+      if (isNaN(this.keyPerformanceMetric.baselineCost)) {
+        this.keyPerformanceMetric.baselineCost = 0;
+      }
     }
-    this.calculateCost();
+    await this.savePerformanceMetric()
+    await this.calculateCostFromKPM({ modifiedMethod: modifiedMethod, updateBaseline: true });
+  }
+
+  async calculateCostFromKPM(kpmChanges: { modifiedMethod: boolean, updateBaseline: boolean }) {
+    if (kpmChanges.modifiedMethod) {
+      this.keyPerformanceMetricImpact.modificationValue = undefined;
+      if(this.keyPerformanceMetricImpact.calculationMethod == 'costPerUnit' && this.keyPerformanceMetric.calculationMethod != 'costPerUnit'){
+        this.keyPerformanceMetricImpact.calculationMethod = 'directCost';
+      }
+    }
+    await this.calculateCost();
   }
 
 
-  calculateCost() {
-    if (this.keyPerformanceMetric.calculationMethod == 'costPerUnit') {
+  async calculateCost() {
+    if (this.keyPerformanceMetricImpact.calculationMethod == 'costPerUnit') {
       this.keyPerformanceMetricImpact.costAdjustment = (this.keyPerformanceMetricImpact.modificationValue * this.keyPerformanceMetric.costPerValue);
-    } else if (this.keyPerformanceMetric.calculationMethod == 'percentTotal') {
+    } else if (this.keyPerformanceMetricImpact.calculationMethod == 'percentTotal') {
       this.keyPerformanceMetricImpact.costAdjustment = this.keyPerformanceMetric.baselineCost * (this.keyPerformanceMetricImpact.modificationValue / 100);
-    } else if(this.keyPerformanceMetric.calculationMethod == 'directCost'){
+    } else if (this.keyPerformanceMetricImpact.calculationMethod == 'directCost') {
       this.keyPerformanceMetricImpact.costAdjustment = this.keyPerformanceMetricImpact.modificationValue;
     }
-    this.saveChanges();
+    await this.saveChanges();
   }
 
   goToMetric() {

--- a/src/app/shared/shared-assessment-forms/neb-forms-accordion/neb-setup-form/performance-metrics-modal/performance-metrics-modal.component.ts
+++ b/src/app/shared/shared-assessment-forms/neb-forms-accordion/neb-setup-form/performance-metrics-modal/performance-metrics-modal.component.ts
@@ -166,7 +166,7 @@ export class PerformanceMetricsModalComponent {
     //make sure metric is tracked in KPI
     let addedMetric: KeyPerformanceMetric = await this.keyPerformanceIndicatorIdbService.addKpmToKpi(this.nonEnergyBenefit.companyId, this.performanceMetricToAdd, this.nonEnergyBenefit.userId, this.nonEnergyBenefit.facilityId);
     let keyPerformanceIndicator: IdbKeyPerformanceIndicator = this.keyPerformanceIndicatorIdbService.getKpiFromKpm(this.nonEnergyBenefit.facilityId, this.performanceMetricToAdd.kpiValue);
-    let newKeyPerformanceMetricImpact: IdbKeyPerformanceMetricImpact = getNewIdbKeyPerformanceMetricImpact(this.nonEnergyBenefit.userId, this.nonEnergyBenefit.companyId, this.nonEnergyBenefit.facilityId, this.nonEnergyBenefit.energyOpportunityId, this.nonEnergyBenefit.guid, addedMetric.value, this.nonEnergyBenefit.assessmentId, keyPerformanceIndicator.guid, addedMetric.guid);
+    let newKeyPerformanceMetricImpact: IdbKeyPerformanceMetricImpact = getNewIdbKeyPerformanceMetricImpact(this.nonEnergyBenefit.userId, this.nonEnergyBenefit.companyId, this.nonEnergyBenefit.facilityId, this.nonEnergyBenefit.energyOpportunityId, this.nonEnergyBenefit.guid, addedMetric.value, this.nonEnergyBenefit.assessmentId, keyPerformanceIndicator.guid, addedMetric.guid, addedMetric.calculationMethod);
     await firstValueFrom(this.keyPerformanceMetricImpactIdbService.addWithObservable(newKeyPerformanceMetricImpact));
     await this.keyPerformanceMetricImpactIdbService.setKeyPerformanceMetricImpacts();
     this.closeAddMetricModal();

--- a/src/app/spec-helpers/spec-test-service-stub.ts
+++ b/src/app/spec-helpers/spec-test-service-stub.ts
@@ -145,7 +145,7 @@ let processEquipmentIdbService: Partial<ProcessEquipmentIdbService> = {
     getFacilityProcessEquipment: () => { return [stubProcessEquipment] }
 }
 
-let stubKpiImpact: IdbKeyPerformanceMetricImpact = getNewIdbKeyPerformanceMetricImpact('123', '123', '123', '123', '123', 'TRIR', '123', '123', '123');
+let stubKpiImpact: IdbKeyPerformanceMetricImpact = getNewIdbKeyPerformanceMetricImpact('123', '123', '123', '123', '123', 'TRIR', '123', '123', '123', 'costPerUnit');
 stubKpiImpact.guid = '123';
 let keyPerformanceMetricImpactIdbService: Partial<KeyPerformanceMetricImpactsIdbService> = {
     keyPerformanceMetricImpacts: new BehaviorSubject<Array<IdbKeyPerformanceMetricImpact>>([stubKpiImpact])


### PR DESCRIPTION
connects #327 

This pull request updates how calculation methods are handled for Key Performance Metric Impacts, ensuring that each impact record explicitly stores and uses its own calculation method rather than relying on the parent metric. It also improves the forms and logic for calculating costs and updating the database.

**Data Model & API Changes**
* Added a new `calculationMethod` field to the `IdbKeyPerformanceMetricImpact` interface and updated its constructor function to require this value, ensuring impacts always have an explicit calculation method. [[1]](diffhunk://#diff-0f2463ae424f63dc5d4fe547717a9acaa2a76838d3a00d71f74e3430d966ff02L17-R22) [[2]](diffhunk://#diff-0f2463ae424f63dc5d4fe547717a9acaa2a76838d3a00d71f74e3430d966ff02L37-R39)
* Updated all calls to `getNewIdbKeyPerformanceMetricImpact` in modal components to pass the calculation method from the metric, ensuring new impacts are initialized correctly. [[1]](diffhunk://#diff-1148d1521a60217ebf99014f3215ac61985a3d9d3f0bdc3d33d109f331a266b8L75-R75) [[2]](diffhunk://#diff-4edeed9a255b59c1205f4f84661aff0bb962ff68e41adc9dc62c88cb56f1cef7L169-R169)

**Database Migration & Consistency**
* Added a migration method `updateMetricImpactCalculationMethods` to `UpdateDbEntriesService` that populates the `calculationMethod` field for existing impacts based on their associated metric, ensuring backward compatibility and data consistency. [[1]](diffhunk://#diff-192c9121f23146a33d523a36242ffbf6fb59975f0473c8f390d35fb470a8e0b2R364-R385) [[2]](diffhunk://#diff-192c9121f23146a33d523a36242ffbf6fb59975f0473c8f390d35fb470a8e0b2R66)

**Form & UI Improvements**
* Refactored the `performance-metric-impact-form` to allow users to select and view calculation methods for both the baseline metric and the impact, and updated input fields to reflect the selected calculation method. [[1]](diffhunk://#diff-da66aa3d595acc68e9c76f238b09f7381f0bdd05ff41846217fe26798209e5dcL57-L63) [[2]](diffhunk://#diff-da66aa3d595acc68e9c76f238b09f7381f0bdd05ff41846217fe26798209e5dcL82-R240)
* Updated the `kpm-details-form` and related templates to remove the "Percent Total" option where appropriate and clarify available calculation method choices. [[1]](diffhunk://#diff-57485fa2f4148bd34c45c7783c0fd5ab661be6dd89e82418df4f72093a3d9eafL49) [[2]](diffhunk://#diff-da66aa3d595acc68e9c76f238b09f7381f0bdd05ff41846217fe26798209e5dcL57-L63)

**Calculation Logic Updates**
* Refactored cost calculation logic in services and components to consistently use the impact's own calculation method, improving correctness when metric and impact methods differ. [[1]](diffhunk://#diff-d288efe2201ae373c5e436738248596bc75144c5da8bead963704712e54d620cL88-R92) [[2]](diffhunk://#diff-a4cde9f48db3358dd5d24d3b0b9b8734250ae68bbd63c2aa76b6804b66db48b4L99-R129)