### PR TITLE
Issue 561 - industrial equipment type default changed to 'Other'

### DIFF
--- a/src/app/models/energyEquipment.ts
+++ b/src/app/models/energyEquipment.ts
@@ -68,7 +68,7 @@ export function getNewIdbEnergyEquipment(userId: string, companyId: string, faci
         companyId: companyId,
         facilityId: facilityId,
         equipmentName: 'New Industrial Equipment',
-        equipmentType: undefined,
+        equipmentType: "Other",
         utilityType: "Electricity",
         size: 0,
         sizeUnit: "kW",


### PR DESCRIPTION
connects #561 

This pull request makes a minor update to the default values for new energy equipment records. Specifically, it sets the `equipmentType` to `"Other"` instead of leaving it undefined.